### PR TITLE
feat: update skill for the v2 API at api.varg.ai/v2

### DIFF
--- a/varg-ai/SKILL.md
+++ b/varg-ai/SKILL.md
@@ -100,10 +100,10 @@ mkdir -p ~/.varg && echo "{\"api_key\":\"$VARG_API_KEY\",\"email\":\"USER_EMAIL\
 Verify the key works:
 
 ```bash
-curl -s -H "Authorization: Bearer $VARG_API_KEY" https://api.varg.ai/v1/balance
+curl -s -H "Authorization: Bearer $VARG_API_KEY" https://api.varg.ai/v2/billing/balance
 ```
 
-You should get `{"balance_cents": ...}`. If you get 401, the key is invalid -- ask the user to double-check it.
+You should get `{"available": ..., "total_balance": ..., ...}` (values in credits/cents). If you get 401, the key is invalid -- ask the user to double-check it.
 
 Also add to the project `.env` if one exists:
 
@@ -113,7 +113,7 @@ echo "VARG_API_KEY=$VARG_API_KEY" >> .env
 
 **Check balance and add credits**
 
-Check `balance_cents` from the verify-otp response or the balance check above. If balance is 0 (or too low for the user's task), the user needs credits before generating anything. 1 credit = 1 cent. A typical video costs $2-5 (200-500 credits).
+Check `balance_cents` from the verify-otp response, or `available` from the balance check above. If balance is 0 (or too low for the user's task), the user needs credits before generating anything. 1 credit = 1 cent. A typical video costs $2-5 (200-500 credits).
 
 Available packages:
 
@@ -159,7 +159,7 @@ Everything you know about varg is likely outdated. Always verify against this sk
 2. **Function calls for media, JSX for composition** -- `Image({...})` creates media, `<Clip>` composes timeline. Never write `<Image prompt="..." />`.
 3. **Cache is sacred** -- identical prompt + params = instant $0 cache hit. When iterating, keep unchanged prompts EXACTLY the same. Never clear cache.
 4. **One image per Video** -- `Video({ prompt: { images: [img] } })` takes exactly one image. Multiple images cause errors.
-5. **Duration constraints differ by model** -- kling-v3: 3-15s (integer only). kling-v2.5: ONLY 5 or 10. Check [models.md](references/models.md).
+5. **Duration constraints differ by model** -- kling_v3: 3-15s (integer only). kling_v2.5: ONLY 5 or 10. Check [models.md](references/models.md).
 6. **Gateway namespace** -- use `providerOptions: { varg: {...} }`, never `fal`, when going through the gateway (both modes).
 7. **Renders cost money** -- 1 credit = 1 cent. A typical 3-clip video costs $2-5. Use preview mode (local) or cheap models to iterate.
 8. **API key hygiene** -- Never write a raw API key value into a bash command. After obtaining a key (from the user or OTP response), immediately `export VARG_API_KEY=...` and use `$VARG_API_KEY` in all subsequent commands. This prevents keys from leaking into conversation context and terminal history.
@@ -169,14 +169,14 @@ Everything you know about varg is likely outdated. Always verify against this sk
 ### Cloud Render (no bun/ffmpeg needed)
 
 ```bash
-# Submit TSX code to the render service
-curl -s -X POST https://render.varg.ai/api/render \
+# Submit TSX code to the render service — returns a job: {"id": "job_xxx", "status": "queued", ...}
+curl -s -X POST https://api.varg.ai/v2/render \
   -H "Authorization: Bearer $VARG_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"code": "const img = Image({ model: varg.imageModel(\"nano-banana-pro\"), prompt: \"a cabin in mountains at sunset\", aspectRatio: \"16:9\" });\nexport default (<Render width={1920} height={1080}><Clip duration={3}>{img}</Clip></Render>);"}'
+  -d '{"code": "const img = Image({ model: varg.imageModel(\"nano_banana_pro\"), prompt: \"a cabin in mountains at sunset\", aspectRatio: \"16:9\" });\nexport default (<Render width={1920} height={1080}><Clip duration={3}>{img}</Clip></Render>);"}'
 
-# Poll for result (repeat until "completed" or "failed")
-curl -s https://render.varg.ai/api/render/jobs/JOB_ID \
+# Poll for result (repeat until "completed" or "failed"; video at output.outputs[0].url)
+curl -s https://api.varg.ai/v2/jobs/JOB_ID \
   -H "Authorization: Bearer $VARG_API_KEY"
 ```
 
@@ -192,7 +192,7 @@ import { createVarg } from "vargai/ai"
 const varg = createVarg({ apiKey: process.env.VARG_API_KEY! })
 
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "a cabin in mountains at sunset",
   aspectRatio: "16:9"
 })
@@ -216,9 +216,10 @@ Full details: [local-render.md](references/local-render.md)
 For one-off images, videos, speech, or music without building a multi-clip template:
 
 ```bash
-curl -X POST https://api.varg.ai/v1/image \
+curl -X POST https://api.varg.ai/v2/image \
   -H "Authorization: Bearer $VARG_API_KEY" \
-  -d '{"model": "nano-banana-pro", "prompt": "a sunset over mountains"}'
+  -H "Content-Type: application/json" \
+  -d '{"model": "nano_banana_pro", "prompt": "a sunset over mountains"}'
 ```
 
 Full API reference: [gateway-api.md](references/gateway-api.md)
@@ -270,15 +271,15 @@ Both modes use `varg.*` for all models. The only difference is imports:
 | Cloud Render | Local Render |
 |---|---|
 | No imports needed (globals are auto-injected) | `import { ... } from "vargai/react"` + `import { createVarg } from "vargai/ai"` |
-| `varg.imageModel("nano-banana-pro")` | `varg.imageModel("nano-banana-pro")` |
-| `varg.videoModel("kling-v3")` | `varg.videoModel("kling-v3")` |
+| `varg.imageModel("nano_banana_pro")` | `varg.imageModel("nano_banana_pro")` |
+| `varg.videoModel("kling_v3")` | `varg.videoModel("kling_v3")` |
 | `varg.speechModel("eleven_v3")` | `varg.speechModel("eleven_v3")` |
 
-**Always use `varg.*Model()`** with `VARG_API_KEY`. It handles routing, caching, billing, and works with a single key. See [byok.md](references/byok.md) for using your own provider keys.
+**Always use `varg.*Model()`** with `VARG_API_KEY`. It handles routing, caching, billing, and works with a single key. BYOK via the API is not available in v2 — see [byok.md](references/byok.md) for what works (local-render direct provider modules only).
 
 ## Cost & Iteration
 
-- **1 credit = 1 cent.** nano-banana-pro = 5 credits, kling-v3 = 150 credits, speech = 20-25 credits.
+- **1 credit = 1 cent.** grok_imagine_image = 4 credits, nano_banana_pro = 126 credits, kling_v3 (5s) = 221 credits, sora_2 (5s) = 105 credits, speech = ~105 credits. Live catalog: `GET https://api.varg.ai/v2/pricing` (no auth). Estimate any request: `POST /v2/estimate`.
 - **Cache saves money.** Keep unchanged prompts character-for-character identical across iterations.
 - **Preview first** (local mode only): `--preview` generates free placeholders to validate structure.
 - Full pricing: [models.md](references/models.md)

--- a/varg-ai/references/byok.md
+++ b/varg-ai/references/byok.md
@@ -1,118 +1,36 @@
-# Bring Your Own Key (BYOK)
+# BYOK (Bring Your Own Key)
 
-Use your own provider API keys with the varg gateway. Requests authenticated with a BYOK key cost $0 in varg credits — you pay the provider directly. You still get gateway benefits: caching, stable URLs, unified API, and job management.
+> **BYOK via the varg API is NOT available in v2.** The v1 `X-Provider-Key-*` headers were not carried over, and passing provider keys in API request bodies is not supported — external providers (fal, elevenlabs, etc.) always run on varg pooled keys with metered credit billing. Do NOT tell users they can get "$0 varg billing" through the API. BYOK support for v2 is planned.
 
-## Why BYOK
+## What works today
 
-- **$0 varg billing** — no credits deducted for BYOK requests
-- **Own quotas** — use your provider's rate limits and spending caps
-- **Same gateway features** — caching (30-day TTL), R2-backed stable URLs, SSE streaming, job polling all work identically
-- **Required**: a `VARG_API_KEY` is still needed for gateway authentication. BYOK replaces only the provider key used for the actual AI generation call.
+### 1. varg credits (the API path — default)
 
-## How It Works
-
-```
-You → gateway (auth via VARG_API_KEY) → resolves provider key → provider API
-```
-
-The gateway resolves which provider key to use in this priority order:
-
-| Priority | Source | Billing |
-|----------|--------|---------|
-| 1 | **Header BYOK** — `X-Provider-Key-*` header on the request | `byok` ($0) |
-| 2 | **Saved BYOK** — provider key saved to your account (encrypted, AES-256-GCM) | `byok` ($0) |
-| 3 | **Pooled key** — varg's shared provider key | `metered` (credits deducted) |
-
-If you pass a BYOK header, it is used immediately. Your key is never stored by the gateway in header mode — it is used for that single request only.
-
-## Provider Keys
-
-| Provider | Header | Env Variable | Get Key |
-|----------|--------|-------------|---------|
-| **fal.ai** (images, video) | `X-Provider-Key-Fal` | `FAL_KEY` | [fal.ai/dashboard/keys](https://fal.ai/dashboard/keys) |
-| **ElevenLabs** (speech, music) | `X-Provider-Key-ElevenLabs` | `ELEVENLABS_API_KEY` | [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys) |
-| **Higgsfield** (soul characters) | `X-Provider-Key-Higgsfield` | `HIGGSFIELD_API_KEY` | [higgsfield.ai](https://higgsfield.ai) |
-| **Replicate** (general models) | `X-Provider-Key-Replicate` | `REPLICATE_API_TOKEN` | [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens) |
-
-## Usage
-
-### Gateway API (curl)
-
-Pass BYOK headers alongside your `Authorization` header:
+One `VARG_API_KEY`, all providers, metered billing:
 
 ```bash
-curl -X POST https://api.varg.ai/v1/image \
-  -H "Authorization: Bearer $VARG_API_KEY" \
-  -H "X-Provider-Key-Fal: $FAL_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "nano-banana-pro", "prompt": "a sunset over mountains"}'
-```
-
-You can mix BYOK and metered in the same session. Only the providers where you supply a header key will use BYOK billing — others fall back to pooled keys.
-
-```bash
-# Image uses your fal key (BYOK, $0), speech uses pooled elevenlabs key (metered)
-curl -X POST https://api.varg.ai/v1/image \
-  -H "Authorization: Bearer $VARG_API_KEY" \
-  -H "X-Provider-Key-Fal: $FAL_KEY" \
-  -d '{"model": "nano-banana-pro", "prompt": "portrait of a warrior"}'
-
-curl -X POST https://api.varg.ai/v1/speech \
-  -H "Authorization: Bearer $VARG_API_KEY" \
-  -d '{"model": "eleven_v3", "text": "Hello world", "voice": "rachel"}'
-```
-
-### Cloud Render
-
-Pass `providerKeys` in the render request body:
-
-```bash
-curl -s -X POST https://render.varg.ai/api/render \
+curl -X POST https://api.varg.ai/v2/image \
   -H "Authorization: Bearer $VARG_API_KEY" \
   -H "Content-Type: application/json" \
-  -d "{
-    \"code\": $(cat video.tsx | jq -Rs .),
-    \"providerKeys\": {
-      \"fal\": \"$FAL_KEY\",
-      \"elevenlabs\": \"$ELEVENLABS_API_KEY\"
-    }
-  }"
+  -d '{"model": "nano_banana_pro", "prompt": "a sunset over mountains"}'
 ```
 
-The render service accepts keys for these providers:
+- Estimate cost before running: `POST /v2/estimate` (same body, no job created)
+- Check balance: `GET /v2/billing/balance`
+- Cache hits are always free (`actual_cost_cents: 0`)
 
-| Provider | `providerKeys` field |
-|----------|---------------------|
-| fal.ai | `fal` |
-| ElevenLabs | `elevenlabs` |
-| Higgsfield | `higgsfield` |
-| Replicate | `replicate` |
-| OpenAI | `openai` |
-| Google | `google` |
-| Together | `together` |
-| Groq | `groq` |
+### 2. Direct provider modules in the local SDK
 
-The last four (OpenAI, Google, Together, Groq) are render-only — they are available as globals in cloud TSX code for direct provider usage but are not routed through the gateway billing system.
-
-### Local Render (TypeScript)
-
-Pass `providerKeys` to `createVarg()`:
+For **local rendering only** (`bunx vargai render`), the SDK ships direct provider modules that call providers with **your own keys from env** — bypassing varg entirely. No varg billing, but also no varg caching or file storage.
 
 ```tsx
 /** @jsxImportSource vargai */
 import { Render, Clip, Image } from "vargai/react"
-import { createVarg } from "vargai/ai"
+import { fal } from "vargai/ai"
 
-const varg = createVarg({
-  apiKey: process.env.VARG_API_KEY!,
-  providerKeys: {
-    fal: process.env.FAL_KEY,
-    elevenlabs: process.env.ELEVENLABS_API_KEY,
-  }
-})
-
+// Uses FAL_KEY / FAL_API_KEY from env — billed by fal directly
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: fal.imageModel("nano_banana_pro"),
   prompt: "a cabin in mountains at sunset",
   aspectRatio: "16:9"
 })
@@ -124,59 +42,39 @@ export default (
 )
 ```
 
-The gateway client automatically converts `providerKeys` to the correct `X-Provider-Key-*` headers on every request.
+Env keys per provider:
 
-### TypeScript Client (no video composition)
+| Provider | Env var | Get key at |
+|----------|---------|------------|
+| fal.ai | `FAL_KEY` or `FAL_API_KEY` | fal.ai/dashboard/keys |
+| ElevenLabs | `ELEVENLABS_API_KEY` | elevenlabs.io/app/settings/api-keys |
+| Higgsfield | `HIGGSFIELD_API_KEY` | higgsfield.ai |
+| OpenAI | `OPENAI_API_KEY` | platform.openai.com |
+| Google | `GOOGLE_API_KEY` | aistudio.google.com |
+| Together | `TOGETHER_API_KEY` | together.ai |
+| Groq | `GROQ_API_KEY` | console.groq.com |
 
-For standalone asset generation via the TypeScript client:
-
-```typescript
-import { VargClient } from "vargai/ai"
-
-const client = new VargClient({
-  apiKey: process.env.VARG_API_KEY!,
-  providerKeys: {
-    fal: process.env.FAL_KEY,
-    elevenlabs: process.env.ELEVENLABS_API_KEY,
-  }
-})
-
-const job = await client.createImage({
-  model: "nano-banana-pro",
-  prompt: "a sunset over mountains"
-})
-
-const result = await client.waitForJob(job.job_id)
-console.log(result.output?.url)
-```
-
-## .env Setup
-
-Store keys in `.env` (Bun auto-loads it, no dotenv needed):
+`.env` example:
 
 ```bash
-# Required — gateway authentication
+# For the varg API + cloud render (billed in varg credits)
 VARG_API_KEY=varg_xxx
 
-# Optional BYOK — supply any or all
+# For local rendering with direct provider modules (billed by providers)
 FAL_KEY=fal_xxx
-ELEVENLABS_API_KEY=el_xxx
-HIGGSFIELD_API_KEY=hf_xxx
-REPLICATE_API_TOKEN=r8_xxx
+ELEVENLABS_API_KEY=xxx
 ```
 
-## Caching with BYOK
+## What does NOT work
 
-Cache works identically with BYOK. The cache key is derived from the request parameters (model, prompt, files, options) — not from which provider key was used. This means:
+- `X-Provider-Key-Fal` / `X-Provider-Key-ElevenLabs` / etc. headers → **ignored in v2**
+- Provider keys in `provider_options` of API requests → not supported for external providers; the request bills varg credits regardless
+- `providerKeys` in cloud render (`POST /v2/render`) → cloud render sub-generations bill varg credits
 
-- A cached result from a metered request can be served to a BYOK request (and vice versa)
-- Cache hits are always $0, regardless of billing mode
-- `Cache-Control: no-cache` bypasses cache as usual
+## Decision guide
 
-## Caveats
-
-- **VARG_API_KEY is always required** — BYOK replaces the provider key, not the gateway auth. You need a varg account.
-- **Header keys are not stored** — the gateway uses header BYOK keys for that single request, then discards them. They are never written to the database.
-- **Rate limits are provider-side** — when using BYOK, your provider account's rate limits apply, not the pooled limits.
-- **Key validation is lazy** — the gateway does not pre-validate BYOK keys. If a key is invalid, you'll get a `502` error when the provider rejects it.
-- **No partial BYOK for a single request** — each request goes to one provider, so one BYOK header is sufficient per request. Multi-provider composition (e.g., fal image + elevenlabs speech in a render) can use separate keys for each provider.
+| Scenario | Use |
+|----------|-----|
+| API access (curl, agents, cloud render) | **varg credits** — the only supported path |
+| Local rendering with existing provider accounts | **Direct provider modules** (`fal.imageModel(...)` + env keys) |
+| Getting started, prototyping | **varg credits** — one key, caching included |

--- a/varg-ai/references/cloud-render.md
+++ b/varg-ai/references/cloud-render.md
@@ -1,8 +1,8 @@
 # Cloud Render Mode
 
-Send TSX code to the varg render service via HTTP. No local dependencies needed -- just a `VARG_API_KEY` and `curl`.
+Send TSX code to `POST https://api.varg.ai/v2/render`. No local dependencies needed -- just a `VARG_API_KEY` and `curl`.
 
-The render service handles all asset generation (images, video, speech, music) and video composition (ffmpeg) in the cloud. You get back a URL to the final `.mp4`.
+The render service handles all asset generation (images, video, speech, music) and video composition (ffmpeg) in the cloud. Rendering is a regular varg job: submit, poll `GET /v2/jobs/{id}`, get the final `.mp4` URL from `output.outputs[0].url`.
 
 ## TSX Format
 
@@ -22,7 +22,7 @@ The user's `VARG_API_KEY` (from the `Authorization` header) is automatically use
 
 ```tsx
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "a cozy cabin in mountains at sunset, warm golden light",
   aspectRatio: "16:9"
 });
@@ -38,13 +38,13 @@ export default (
 
 ```tsx
 const hero = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "cinematic portrait of a warrior princess, golden hour lighting",
   aspectRatio: "9:16"
 });
 
 const scene = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "warrior walks forward through misty forest, camera follows", images: [hero] },
   duration: 5
 });
@@ -86,7 +86,7 @@ Write the TSX code to a local `.tsx` file for reference and iteration:
 ```bash
 cat > video.tsx << 'EOF'
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "a sunset over mountains",
   aspectRatio: "16:9"
 });
@@ -102,65 +102,77 @@ EOF
 ### Step 2: Submit to render service
 
 ```bash
-curl -s -X POST https://render.varg.ai/api/render \
+curl -s -X POST https://api.varg.ai/v2/render \
   -H "Authorization: Bearer $VARG_API_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"code\": $(cat video.tsx | jq -Rs .)}"
 ```
 
-Response (`202 Accepted`):
+Response (`202 Accepted`) is a standard varg job:
 
 ```json
 {
-  "job_id": "550e8400-e29b-41d4-a716-446655440000",
-  "status": "rendering",
-  "estimated_duration_ms": 35000
+  "id": "job_a1b2c3d4e5f6",
+  "status": "queued",
+  "tool": "render",
+  "estimated_duration_ms": 35000,
+  "urls": {
+    "self": "https://api.varg.ai/v2/jobs/job_a1b2c3d4e5f6",
+    "status": "https://api.varg.ai/v2/jobs/job_a1b2c3d4e5f6/status",
+    "cancel": "https://api.varg.ai/v2/jobs/job_a1b2c3d4e5f6/cancel"
+  }
 }
 ```
 
-> **Note**: The submit and poll examples use [`jq`](https://jqlang.github.io/jq/) for JSON parsing. If `jq` is not available, extract fields with `grep -o '"job_id":"[^"]*"' | cut -d'"' -f4`.
+> **Note**: The submit and poll examples use [`jq`](https://jqlang.github.io/jq/) for JSON parsing. If `jq` is not available, extract fields with `grep -o '"id":"job_[^"]*"' | cut -d'"' -f4`.
 
 ### Step 3: Poll for result
 
-Poll every 10-15 seconds until `status` is `"completed"` or `"failed"`:
+Poll every 10-15 seconds until `status` is `"completed"`, `"failed"`, or `"cancelled"`:
 
 ```bash
-curl -s https://render.varg.ai/api/render/jobs/JOB_ID \
+curl -s https://api.varg.ai/v2/jobs/JOB_ID \
   -H "Authorization: Bearer $VARG_API_KEY"
 ```
+
+While running, `GET /v2/jobs/JOB_ID/status` gives lightweight progress (`progress` 0..1, `progress_message` like `"stitching 3/8 (40%)"`).
 
 Completed response:
 
 ```json
 {
+  "id": "job_a1b2c3d4e5f6",
   "status": "completed",
-  "output_url": "https://s3.varg.ai/renders/xxx.mp4",
-  "files": [
-    { "url": "https://...", "mediaType": "image/png", "metadata": { "type": "image", "prompt": "..." } }
-  ],
-  "duration_ms": 45000
+  "output": {
+    "version": "v1",
+    "outputs": [
+      {
+        "url": "https://s3.varg.ai/files/acc_x/render_abc.mp4",
+        "file_id": "file_render_abc",
+        "media_type": "video/mp4",
+        "thumbnail_url": "https://s3.varg.ai/thumbs/file_render_abc.jpg"
+      }
+    ]
+  },
+  "actual_cost_cents": 5
 }
 ```
 
-On success, present the `output_url` to the user. The `files` array contains all intermediate assets (images, audio).
+On success, present `output.outputs[0].url` to the user. AI sub-generation assets are linked to the render job and available via `GET /v2/files` — if the render fails partway, completed assets are still recoverable there.
 
-On failure:
+On failure, the `error` field describes what went wrong:
 
 ```json
 {
   "status": "failed",
-  "error": "Insufficient balance",
-  "error_category": "quota_exceeded"
+  "error": { "code": "insufficient_balance", "message": "Insufficient balance" }
 }
 ```
 
-### Alternative: SSE Stream
+Retry a failed render with `POST /v2/jobs/JOB_ID/retry` — cached sub-generations are reused for free.
 
-Instead of polling, use Server-Sent Events for real-time updates:
+### Alternative: webhook instead of polling
 
-```bash
-curl -N https://render.varg.ai/api/render/jobs/JOB_ID/stream \
-  -H "Authorization: Bearer $VARG_API_KEY"
-```
+Add `"options": {"webhook_url": "https://your-server/hook"}` to the request body — varg POSTs the job snapshot when the render finishes (signed `X-Varg-Signature`, 8 retries). There is no SSE stream in v2.
 
-For the full Render API reference (rate limits, error codes, all endpoints), see [gateway-api.md](gateway-api.md).
+For the full API reference (rate limits, error codes, all endpoints), see [gateway-api.md](gateway-api.md).

--- a/varg-ai/references/common-errors.md
+++ b/varg-ai/references/common-errors.md
@@ -2,13 +2,13 @@
 
 ## Duration Constraint Violations
 
-### kling-v2.5: "422 Unprocessable Entity"
+### kling_v2.5: "422 Unprocessable Entity"
 
-**Cause**: kling-v2.5 only accepts duration `5` or `10`. Any other value (3, 7, 12, etc.) fails.
+**Cause**: kling_v2.5 only accepts duration `5` or `10`. Any other value (3, 7, 12, etc.) fails.
 
-**Fix**: Use exactly `duration: 5` or `duration: 10`. Or switch to kling-v3 which accepts any integer 3-15.
+**Fix**: Use exactly `duration: 5` or `duration: 10`. Or switch to kling_v3 which accepts any integer 3-15.
 
-### kling-v3: duration must be integer 3-15
+### kling_v3: duration must be integer 3-15
 
 **Cause**: Non-integer or out-of-range duration.
 
@@ -64,52 +64,52 @@ Rule: match the namespace to the provider you're using. Gateway = `varg`. Direct
 **Fix**: Media generation must use function calls:
 ```tsx
 // CORRECT
-const img = Image({ model: varg.imageModel("nano-banana-pro"), prompt: "..." })
+const img = Image({ model: varg.imageModel("nano_banana_pro"), prompt: "..." })
 
 // WRONG
-const img = <Image model={varg.imageModel("nano-banana-pro")} prompt="..." />
+const img = <Image model={varg.imageModel("nano_banana_pro")} prompt="..." />
 ```
 
 JSX is only for composition components: `<Render>`, `<Clip>`, `<Music>`, `<Captions>`, `<Title>`, `<Overlay>`, `<Split>`, `<Grid>`, `<Packshot>`.
 
 ---
 
-## nano-banana-pro/edit: Missing Images
+## nano_banana_pro/edit: Missing Images
 
 **Error**: "images is required" or generation produces generic image ignoring reference.
 
-**Cause**: Using `nano-banana-pro/edit` with a plain string prompt instead of `{ text, images }`.
+**Cause**: Using `nano_banana_pro/edit` with a plain string prompt instead of `{ text, images }`.
 
 **Fix**:
 ```tsx
 // CORRECT
 Image({
-  model: varg.imageModel("nano-banana-pro/edit"),
+  model: varg.imageModel("nano_banana_pro/edit"),
   prompt: { text: "same person on a beach", images: [referenceImage] }
 })
 
 // WRONG
 Image({
-  model: varg.imageModel("nano-banana-pro/edit"),
+  model: varg.imageModel("nano_banana_pro/edit"),
   prompt: "same person on a beach"
 })
 ```
 
 ---
 
-## nano-banana-pro (non-edit): Wrong Prompt Format
+## nano_banana_pro (non-edit): Wrong Prompt Format
 
 **Error**: Unexpected results or errors.
 
-**Cause**: Passing `{ text, images }` object to `nano-banana-pro` (non-edit variant).
+**Cause**: Passing `{ text, images }` object to `nano_banana_pro` (non-edit variant).
 
-**Fix**: `nano-banana-pro` (without `/edit`) takes a plain string:
+**Fix**: `nano_banana_pro` (without `/edit`) takes a plain string:
 ```tsx
 // CORRECT
-Image({ model: varg.imageModel("nano-banana-pro"), prompt: "a sunset over the ocean" })
+Image({ model: varg.imageModel("nano_banana_pro"), prompt: "a sunset over the ocean" })
 
 // WRONG
-Image({ model: varg.imageModel("nano-banana-pro"), prompt: { text: "a sunset", images: [] } })
+Image({ model: varg.imageModel("nano_banana_pro"), prompt: { text: "a sunset", images: [] } })
 ```
 
 ---
@@ -154,9 +154,9 @@ const vid = Video({ ..., duration: 5 })
 **Cause**: Not enough credits for the requested generation.
 
 **Fix**: 
-- Check balance: `GET /v1/balance`
+- Check balance: `GET https://api.varg.ai/v2/billing/balance` (the `available` field)
+- Estimate before running: `POST /v2/estimate` with the same body
 - Use cheaper models (see [models.md](models.md))
-- Use BYOK headers to bypass billing
 
 ---
 
@@ -179,7 +179,7 @@ const vid = Video({ ..., duration: 5 })
 **Fix for render service**: Don't import anything. All components and providers are auto-provided as globals:
 ```tsx
 // In render service (no imports needed)
-const img = Image({ model: varg.imageModel("nano-banana-pro"), prompt: "..." })
+const img = Image({ model: varg.imageModel("nano_banana_pro"), prompt: "..." })
 export default <Render>...</Render>
 ```
 
@@ -196,13 +196,13 @@ import { createVarg } from "vargai/ai"
 
 **Error**: Render job stays in "processing" or times out after 10-15 minutes.
 
-**Cause**: Complex renders with many AI generation calls can take 15+ minutes. Video models like kling-v3 take 2-5 minutes per clip.
+**Cause**: Complex renders with many AI generation calls can take 15+ minutes. Video models like kling_v3 take 2-5 minutes per clip.
 
 **Fix**:
 - Use `--preview` first to validate structure
 - Break very long sequences into separate render jobs
-- Use faster/cheaper models for prototyping (flux-schnell, ltx-2-19b-distilled)
-- Check job status via SSE stream: `GET /v1/jobs/{id}/stream`
+- Use faster/cheaper models for prototyping (flux_schnell, ltx_2_19b_distilled)
+- Check job progress: `GET /v2/jobs/{id}/status` (`progress` 0..1, `progress_message`)
 
 ---
 

--- a/varg-ai/references/components.md
+++ b/varg-ai/references/components.md
@@ -93,7 +93,7 @@ Available `name` values (any FFmpeg xfade transition name works):
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `model` | `ImageModelV3` | Required. e.g. `varg.imageModel("nano-banana-pro")` |
+| `model` | `ImageModelV3` | Required. e.g. `varg.imageModel("nano_banana_pro")` |
 | `prompt` | `string \| { text, images }` | Text prompt or edit prompt with references |
 | `aspectRatio` | `string` | `"16:9"`, `"9:16"`, `"1:1"`, `"4:3"`, `"3:4"`, `"4:5"` |
 | `zoom` | `"in" \| "out" \| "left" \| "right"` | Ken Burns zoom/pan animation (for slideshows) |
@@ -105,14 +105,14 @@ Available `name` values (any FFmpeg xfade transition name works):
 ```tsx
 // Text-to-image
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "cinematic portrait, golden hour",
   aspectRatio: "9:16"
 })
 
 // Reference editing
 const edited = Image({
-  model: varg.imageModel("nano-banana-pro/edit"),
+  model: varg.imageModel("nano_banana_pro/edit"),
   prompt: { text: "same person on a beach", images: [referenceImage] },
   aspectRatio: "9:16"
 })
@@ -125,28 +125,28 @@ Add cinematic motion to still images in slideshows. The `zoom` prop creates a sl
 ```tsx
 // Slow zoom in -- dramatic reveal
 const landscape = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "vast mountain range at sunset, layers of purple and gold",
   zoom: "in"
 })
 
 // Slow zoom out -- establishing shot
 const portrait = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "warrior princess, piercing emerald eyes, battle-worn silver armor",
   zoom: "out"
 })
 
 // Pan left -- panoramic sweep
 const cityscape = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "tokyo skyline at night, neon lights reflecting on wet streets",
   zoom: "left"
 })
 
 // Pan right
 const beach = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "tropical beach at golden hour, palm trees silhouetted",
   zoom: "right"
 })
@@ -177,7 +177,7 @@ Control how images/videos fill the frame when their aspect ratio doesn't match t
 ```tsx
 // Contain with blurred background (popular for portrait-in-landscape)
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "portrait photo",
   aspectRatio: "9:16",
   resize: "contain-blur"
@@ -192,7 +192,7 @@ const img = Image({
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `model` | `VideoModelV3` | Required. e.g. `varg.videoModel("kling-v3")` |
+| `model` | `VideoModelV3` | Required. e.g. `varg.videoModel("kling_v3")` |
 | `prompt` | `string \| { text?, images?, audio?, video? }` | Prompt with optional media inputs |
 | `duration` | `number` | Duration in seconds. Check model constraints! |
 | `aspectRatio` | `string` | `"16:9"`, `"9:16"`, `"1:1"` |
@@ -201,21 +201,21 @@ const img = Image({
 ```tsx
 // Text-to-video
 const vid = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: "a bird soaring over mountains, aerial shot",
   duration: 5
 })
 
 // Image-to-video (ONE image only)
 const animated = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "person starts walking forward", images: [characterImage] },
   duration: 5
 })
 
 // Lipsync — image + audio (VEED, recommended)
 const talking = Video({
-  model: varg.videoModel("veed-fabric-1.0"),
+  model: varg.videoModel("veed_fabric_1.0"),
   keepAudio: true,
   prompt: { images: [portrait], audio: voiceover }
 })
@@ -440,13 +440,13 @@ Used inside Grid or Split for fine positioning.
 
 Combines an image + speech into a lipsync talking-head video. **Must be called as a function, not JSX.** Requires three props: `image`, `audio`, and `model`.
 
-**Best model: `veed-fabric-1.0`** — takes image + audio directly (one step, fastest). For sync-v2/sync-v3, TalkingHead auto-animates the image first then lipsyncs (two-step, slower).
+**Best model: `veed_fabric_1.0`** — takes image + audio directly (one step, fastest). For sync_v2/sync-v3, TalkingHead auto-animates the image first then lipsyncs (two-step, slower).
 
 | Prop | Type | Required | Description |
 |------|------|----------|-------------|
 | `image` | `VargElement<"image">` | **Yes** | An `Image()` element (the character portrait) |
 | `audio` | `VargElement<"speech">` | **Yes** | A `Speech()` element (the voiceover — await first for duration) |
-| `model` | `VideoModelV3` | **Yes** | Lipsync model. Use `varg.videoModel("veed-fabric-1.0")` (recommended) |
+| `model` | `VideoModelV3` | **Yes** | Lipsync model. Use `varg.videoModel("veed_fabric_1.0")` (recommended) |
 | `lipsyncModel` | `VideoModelV3` | No | Override lipsync model (defaults to `model`) |
 | `resolution` | `"480p" \| "720p" \| "1080p"` | No | Video resolution (default: `"720p"`) |
 | `position` | `Position \| object` | No | Position within the clip |
@@ -456,7 +456,7 @@ Combines an image + speech into a lipsync talking-head video. **Must be called a
 
 ```tsx
 const portrait = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "friendly female host, studio background, looking at camera",
   aspectRatio: "9:16"
 })
@@ -470,7 +470,7 @@ const audio = await Speech({
 export default (
   <Render width={1080} height={1920}>
     <Clip duration={audio.duration}>
-      <TalkingHead image={portrait} audio={audio} model={varg.videoModel("veed-fabric-1.0")} />
+      <TalkingHead image={portrait} audio={audio} model={varg.videoModel("veed_fabric_1.0")} />
       <Captions src={audio} style="tiktok" />
     </Clip>
   </Render>

--- a/varg-ai/references/gateway-api.md
+++ b/varg-ai/references/gateway-api.md
@@ -1,6 +1,6 @@
-# Gateway API Reference
+# varg API Reference (v2)
 
-The varg gateway at `api.varg.ai` provides a unified REST API for generating images, videos, speech, and music with a single API key. Use this for one-off asset generation without building a full TSX template.
+The varg API at `api.varg.ai/v2` is a unified REST API for generating images, videos, speech, music, and full rendered videos with a single API key. Use this for one-off asset generation without building a full TSX template, or `POST /v2/render` for cloud rendering.
 
 ## Authentication
 
@@ -8,61 +8,79 @@ The varg gateway at `api.varg.ai` provides a unified REST API for generating ima
 Authorization: Bearer varg_xxx
 ```
 
-Get your API key at the varg dashboard.
+Get your API key at the varg dashboard (app.varg.ai). Only `GET /v2/pricing` is public.
 
 ## Base URL
 
 ```
-https://api.varg.ai/v1
+https://api.varg.ai/v2
 ```
 
 ---
 
-## Endpoints
+## Core concepts
+
+| Concept | Example | What it is |
+|---------|---------|------------|
+| **Tool** | `image`, `video`, `speech` | A capability with its own endpoint (`POST /v2/image`) |
+| **Model** | `flux_schnell`, `kling_v3` | The `model` field. One model can be served by multiple providers |
+| **Provider** | `fal`, `elevenlabs` | Who runs the generation. varg picks automatically, or pin with `fal:flux_schnell` |
+
+Model ids use underscores (`kling_v3`, `nano_banana_pro`). Dashed spellings (`kling-v3`) are accepted and normalized.
+
+---
+
+## Generation endpoints
+
+All return `202 Accepted` with a job. Poll `GET /v2/jobs/{id}` until terminal.
 
 ### Generate Image
 
 ```bash
-POST /v1/image
+POST /v2/image
 ```
 
 ```json
 {
-  "model": "nano-banana-pro",
+  "model": "nano_banana_pro",
   "prompt": "a sunset over mountains, cinematic, golden hour",
   "aspect_ratio": "16:9"
 }
 ```
 
+Image editing: send a source image in `files` with an edit model (`nano_banana_pro/edit`). Upscaling: `clarity_upscaler`, `aura_sr`, `topaz`.
+
 ### Generate Video
 
 ```bash
-POST /v1/video
+POST /v2/video
 ```
 
 ```json
 {
-  "model": "kling-v3",
+  "model": "kling_v3",
   "prompt": "a bird soaring over mountains, aerial shot",
   "duration": 5,
   "aspect_ratio": "16:9"
 }
 ```
 
-With image input (image-to-video):
+Image-to-video (start frame in `files` — varg routes to the model's i2v variant automatically):
 ```json
 {
-  "model": "kling-v3",
+  "model": "kling_v3",
   "prompt": "person starts walking forward",
-  "files": [{ "url": "https://s3.varg.ai/uploads/character.png" }],
+  "files": [{ "url": "https://s3.varg.ai/files/acc_x/character.png" }],
   "duration": 5
 }
 ```
 
+Lipsync (video + audio in `files`): `sync_v2`, `veed_fabric_1.0`, `omnihuman_v1.5`. Video upscale: `topaz_video`, `seedvr_video`.
+
 ### Generate Speech
 
 ```bash
-POST /v1/speech
+POST /v2/speech
 ```
 
 ```json
@@ -76,7 +94,7 @@ POST /v1/speech
 ### Generate Music
 
 ```bash
-POST /v1/music
+POST /v2/music
 ```
 
 ```json
@@ -90,7 +108,7 @@ POST /v1/music
 ### Transcribe Audio
 
 ```bash
-POST /v1/transcription
+POST /v2/transcription
 ```
 
 ```json
@@ -100,98 +118,217 @@ POST /v1/transcription
 }
 ```
 
+### FFmpeg operations
+
+One endpoint, operation selected by `model`:
+
+```bash
+POST /v2/ffmpeg
+```
+
+| Model | Operation | Key fields |
+|-------|-----------|------------|
+| `rendi_ffmpeg_trim` | Trim | `url`, `start`, `end` or `duration`, `precise` |
+| `rendi_ffmpeg_resize` | Resize | `url`, `width`/`height`, `fit` (cover/contain/stretch) |
+| `rendi_ffmpeg_slice` | Slice into segments | `video_url`, `every`/`at`/`count`/`ranges`, `thumbnails` |
+| `rendi_ffmpeg` | Generic command | `command` with `{{in_1}}`/`{{out_1}}`, `input_files`, `output_files` |
+
+```json
+{
+  "model": "rendi_ffmpeg_trim",
+  "url": "https://s3.varg.ai/files/acc_x/video.mp4",
+  "start": 2.5,
+  "duration": 5
+}
+```
+
+All ffmpeg ops cost ~6 credits. To probe media metadata (dimensions, duration) synchronously without a job, use `POST /v2/files/probe` with `{"url": "..."}`.
+
+### Render (cloud video composition)
+
+```bash
+POST /v2/render
+```
+
+```json
+{
+  "code": "<TSX code string with export default>",
+  "mode": "strict",
+  "output": "video",
+  "verbose": false
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `code` | `string` | Yes | TSX code with `export default` returning a `<Render>` element |
+| `mode` | `"strict" \| "preview"` | No | `"preview"` uses placeholders for failed generations |
+| `output` | `"video" \| "frames"` | No | `"frames"` skips stitching for image-only renders |
+| `verbose` | `boolean` | No | Detailed logging (default: false) |
+
+Render is a regular job — poll `GET /v2/jobs/{id}`, final video at `output.outputs[0].url`. Billing: flat ~5 credit stitching fee + each AI sub-generation billed as its own job. See [cloud-render.md](cloud-render.md) for the full workflow and TSX format.
+
 ### Upload File
 
 ```bash
-POST /v1/files
-Content-Type: application/octet-stream
+POST /v2/files
+Content-Type: image/jpeg        # the file's media type
+X-Filename: photo.jpg           # optional
+X-Content-Hash: sha256:<hex>    # optional, enables dedup
 ```
 
-Binary body. Max 50MB. Returns a public URL.
+Raw binary body. **Max 200MB.** Returns `{"file_id": "file_xxx", "url": "https://s3.varg.ai/...", ...}`.
+
+Import by URL instead of uploading bytes:
+
+```bash
+POST /v2/files/import
+{"url": "https://example.com/photo.jpg"}
+```
+
+Dedup pre-check before uploading: `GET /v2/files/check?hash=sha256:<hex>`.
 
 ---
 
 ## Job Lifecycle
 
-All generation endpoints return `202 Accepted` with a job reference:
+```
+queued → submitting → running → completed | failed | cancelled
+```
+
+All generation endpoints return `202 Accepted` with a job:
 
 ```json
 {
-  "job_id": "abc123",
+  "id": "job_a1b2c3d4e5f6",
   "status": "queued",
-  "model": "kling-v3",
-  "created_at": "2026-01-15T10:30:00Z",
-  "cache": { "hit": false }
+  "tool": "video",
+  "input": { "model": "kling_v3", "prompt": "..." },
+  "estimated_cost_cents": 221,
+  "pricing": { "estimated": 221, "billing": "metered" },
+  "urls": {
+    "self": "https://api.varg.ai/v2/jobs/job_a1b2c3d4e5f6",
+    "status": "https://api.varg.ai/v2/jobs/job_a1b2c3d4e5f6/status",
+    "cancel": "https://api.varg.ai/v2/jobs/job_a1b2c3d4e5f6/cancel",
+    "retry": "https://api.varg.ai/v2/jobs/job_a1b2c3d4e5f6/retry"
+  }
 }
 ```
 
 ### Poll for Result
 
 ```bash
-GET /v1/jobs/{job_id}
+GET /v2/jobs/{id}
 ```
 
-Returns current status. When `status: "completed"`:
+When `status: "completed"`, the result is in `output.outputs[]`:
 
 ```json
 {
-  "job_id": "abc123",
+  "id": "job_a1b2c3d4e5f6",
   "status": "completed",
   "output": {
-    "url": "https://s3.varg.ai/o/abc123.mp4",
-    "media_type": "video/mp4"
-  }
+    "version": "v1",
+    "outputs": [
+      {
+        "url": "https://s3.varg.ai/files/acc_x/file_abc.mp4",
+        "file_id": "file_abc123",
+        "media_type": "video/mp4",
+        "thumbnail_url": "https://s3.varg.ai/thumbs/file_abc123.jpg"
+      }
+    ]
+  },
+  "actual_cost_cents": 221
 }
 ```
 
-### SSE Stream (real-time updates)
+Lightweight polling (includes `progress` 0..1 and `progress_message`):
 
 ```bash
-GET /v1/jobs/{job_id}/stream
-Accept: text/event-stream
+GET /v2/jobs/{id}/status
 ```
 
-Receives real-time status events. Preferred over polling.
+There is **no SSE stream** — poll, or use webhooks.
 
-### Cancel Job
+### Webhooks (instead of polling)
+
+Add `options.webhook_url` to any generation request. When the job reaches a terminal status, varg POSTs the job snapshot to your URL, signed with `X-Varg-Signature: v1=<hmac-sha256>`, with 8 retries.
+
+```json
+{
+  "model": "kling_v3",
+  "prompt": "...",
+  "options": { "webhook_url": "https://example.com/varg-hook" }
+}
+```
+
+### Job actions
 
 ```bash
-DELETE /v1/jobs/{job_id}
+POST /v2/jobs/{id}/cancel    # abort a running job (409 if terminal)
+POST /v2/jobs/{id}/retry     # retry a failed job
+POST /v2/jobs/{id}/refresh   # force re-poll of the provider
+GET  /v2/jobs/{id}/price     # pricing breakdown (estimated/actual/billed_units)
+GET  /v2/jobs                # list your jobs
+```
+
+### Idempotency
+
+Pass `Idempotency-Key: <any unique string>` on job-creating POSTs. Retrying with the same key returns the existing job (`200`) instead of creating and charging a new one (`202`). Use this to make retries safe.
+
+---
+
+## Tools discovery (for agents)
+
+Discover the API surface at runtime without docs:
+
+```bash
+GET  /v2/tools                          # list all tools
+GET  /v2/tools/{tool_key}               # input JSON Schema + output shape + worked example
+GET  /v2/tools/{tool_key}?model=X       # explicit per-provider options for model X
+POST /v2/tools/{tool_key}/call          # generic call (same as POST /v2/{tool_key})
 ```
 
 ---
 
 ## Cache Behavior
 
-Identical requests (same model + prompt + parameters) return cached results instantly at zero cost.
-
-- Cache TTL: 30 days
-- Cache headers: `X-Cache: HIT|MISS`, `X-Cache-Key`, `X-Cache-TTL`
-- To bypass cache: `Cache-Control: no-cache`
+Identical requests (same model + prompt + parameters) return a completed job instantly with `actual_cost_cents: 0` and `pricing.cached: true`. **Cache hits are free.**
 
 ---
 
-## BYOK (Bring Your Own Key)
+## Pricing & Billing
 
-Use your own provider API keys for $0 varg billing. Pass keys as headers alongside your `Authorization` header:
+1 credit = 1 cent = $0.01. Flow: **reserve** estimated cost at creation (402 if insufficient) → **commit** on completion → **release** on failure.
 
 ```bash
-curl -X POST https://api.varg.ai/v1/image \
-  -H "Authorization: Bearer $VARG_API_KEY" \
-  -H "X-Provider-Key-Fal: $FAL_KEY" \
-  -d '{"model": "nano-banana-pro", "prompt": "a sunset over mountains"}'
+GET  /v2/pricing              # public model catalog with prices (no auth)
+POST /v2/estimate             # price a request WITHOUT creating a job (same body as generation)
+GET  /v2/billing/balance      # balance breakdown
+GET  /v2/billing/usage        # usage records (?from=&to=)
+GET  /v2/billing/transactions # ledger (spend/topup history)
 ```
 
-| Provider | Header |
-|----------|--------|
-| fal.ai | `X-Provider-Key-Fal` |
-| ElevenLabs | `X-Provider-Key-ElevenLabs` |
-| Higgsfield | `X-Provider-Key-Higgsfield` |
-| Replicate | `X-Provider-Key-Replicate` |
+Balance response:
 
-When a BYOK header is present, the gateway routes through your key and doesn't deduct credits. You still need `VARG_API_KEY` for gateway authentication.
+```json
+{
+  "available": 8200,
+  "reserved": 300,
+  "total_balance": 8500,
+  "subscription_balance": 5000,
+  "rollover_balance": 2000,
+  "onetime_balance": 1500
+}
+```
 
-For the full BYOK guide (TypeScript client, cloud render, local render, provider key setup), see [byok.md](byok.md).
+`available` = total − reserved (what you can spend right now).
+
+---
+
+## BYOK
+
+**BYOK via the API is not available in v2.** The v1 `X-Provider-Key-*` headers were not ported. All API requests bill varg credits. For local rendering with your own provider keys (env `FAL_KEY`, etc.), see [byok.md](byok.md).
 
 ---
 
@@ -208,7 +345,7 @@ const varg = createVarg({ apiKey: process.env.VARG_API_KEY! })
 import { generateImage } from "ai"
 
 const result = await generateImage({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "a sunset over mountains"
 })
 ```
@@ -221,239 +358,50 @@ The `vargai/ai` package implements the Vercel AI SDK `ProviderV3` interface, exp
 
 ---
 
-## Account & Usage
-
-```bash
-GET /v1/balance      # Credit balance
-GET /v1/usage        # Usage records (optional: ?from=2026-01-01&to=2026-01-31)
-GET /v1/pricing      # Model pricing
-GET /v1/voices       # Available ElevenLabs voices
-```
-
----
-
 ## Error Responses
 
-| Status | Meaning |
-|--------|---------|
-| 400 | Invalid request (check model ID, prompt format) |
-| 401 | Invalid or missing API key |
-| 402 | Insufficient credits |
-| 404 | Job not found |
-| 429 | Rate limited (240 requests/minute) |
-| 502 | Provider error (fal/elevenlabs/etc. failed) |
+All errors use one envelope:
 
-Error response format:
 ```json
 {
-  "error": "InsufficientBalanceError",
-  "message": "Insufficient balance. Required: 150 credits, available: 50 credits"
+  "error": {
+    "code": "insufficient_balance",
+    "message": "Insufficient balance to run this job"
+  }
 }
 ```
+
+| Status | Code | Meaning |
+|--------|------|---------|
+| 400 | `invalid_request`, `invalid_json` | Malformed body |
+| 401 | `unauthorized` | Invalid or missing API key |
+| 402 | `insufficient_balance` | Balance too low to reserve estimated cost |
+| 404 | `model_not_found`, `tool_not_found`, `job_not_found`, `file_not_found` | Unknown resource |
+| 409 | — | Job already terminal (cancel/refresh) |
+| 413 | `file_too_large` | Upload over 200MB |
+| 422 | `invalid_request` | Body failed schema validation |
+| 429 | `rate_limited` | Too many requests — honor `Retry-After` |
+| 503 | `no_pricing` | Model temporarily has no active pricing |
+
+Rate limiting is a sliding window per API key; responses carry `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`.
 
 ---
 
-## Render API (Video Composition)
+## Migrating from v1
 
-For composing multi-clip videos with transitions, music, captions, and effects, use the render service. This takes TSX code and produces a final `.mp4` video. The render service handles all asset generation (images, video, speech, music) and ffmpeg composition in the cloud.
-
-### Base URL
-
-```
-https://render.varg.ai
-```
-
-### Submit Render Job
-
-```bash
-POST /api/render
-Authorization: Bearer varg_xxx
-Content-Type: application/json
-```
-
-Request body:
-
-```json
-{
-  "code": "<TSX code string with export default>",
-  "verbose": false,
-  "mode": "strict"
-}
-```
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `code` | `string` | Yes | TSX code with `export default`. No imports needed -- all components are globals. |
-| `verbose` | `boolean` | No | Enable verbose logging (default: false) |
-| `mode` | `"strict" \| "preview"` | No | `"preview"` uses cheaper placeholders |
-
-Response (`202 Accepted`):
-
-```json
-{
-  "job_id": "550e8400-e29b-41d4-a716-446655440000",
-  "status": "rendering",
-  "estimated_duration_ms": 35000,
-  "queue": { "active": 3, "waiting": 0 }
-}
-```
-
-### Poll Job Status
-
-```bash
-GET /api/render/jobs/{job_id}
-Authorization: Bearer varg_xxx
-```
-
-Response (`200 OK`):
-
-```json
-{
-  "job_id": "550e8400-e29b-41d4-a716-446655440000",
-  "status": "completed",
-  "output_url": "https://s3.varg.ai/renders/1710345600_abc123.mp4",
-  "files": [
-    {
-      "url": "https://s3.varg.ai/cache/def456.png",
-      "mediaType": "image/png",
-      "metadata": { "type": "image", "model": "flux-schnell", "prompt": "..." }
-    }
-  ],
-  "duration_ms": 45000,
-  "created_at": "2026-03-13T12:00:00Z",
-  "completed_at": "2026-03-13T12:00:45Z"
-}
-```
-
-Status values: `"rendering"`, `"completed"`, `"failed"`.
-
-On failure, `error` and `error_category` fields are included:
-
-```json
-{
-  "status": "failed",
-  "error": "Insufficient balance",
-  "error_category": "quota_exceeded"
-}
-```
-
-Error categories: `quota_exceeded`, `rate_limited`, `timeout`, `invalid_source`, `internal`.
-
-### SSE Stream (Real-Time Updates)
-
-```bash
-GET /api/render/jobs/{job_id}/stream
-Authorization: Bearer varg_xxx
-Accept: text/event-stream
-```
-
-Receives real-time status events. Preferred over polling for long-running renders:
-
-```
-event: status
-data: {"job_id":"...","status":"rendering","started_at":"..."}
-
-:keepalive
-
-event: status
-data: {"job_id":"...","status":"completed","output_url":"https://...","files":[...]}
-```
-
-### List Jobs
-
-```bash
-GET /api/jobs?limit=50
-Authorization: Bearer varg_xxx
-```
-
-Returns recent render jobs for the authenticated user.
-
-### Rate Limits
-
-| Limit | Value |
-|-------|-------|
-| Requests per minute | 10 per user |
-| Concurrent jobs | 5 per user |
-| Job timeout | 15 minutes |
-
-Rate limit info is returned in response headers:
-
-```
-X-RateLimit-Limit: 10
-X-RateLimit-Remaining: 9
-X-RateLimit-Reset: 2026-03-13T12:01:00.000Z
-```
-
-### Cloud Render TSX Format
-
-No imports needed -- all components and providers are auto-injected as globals. The user's API key (from the `Authorization` header) is used for all AI generation calls automatically.
-
-**Available globals:**
-
-| Category | Globals |
-|----------|---------|
-| Components | `Render`, `Clip`, `Image`, `Video`, `Speech`, `Music`, `Captions`, `Title`, `Subtitle`, `Overlay`, `Split`, `Grid`, `Slot`, `Slider`, `Swipe`, `Packshot`, `TalkingHead` |
-| Providers | `fal`, `elevenlabs`, `higgsfield`, `openai`, `replicate`, `google`, `together` |
-| Data | `VOICES` (voice name to ElevenLabs ID mapping) |
-
-**Restrictions:**
-
-- Must have `export default` returning a `<Render>` element
-- No named exports (`export const x = ...` is forbidden)
-- No external imports (`vargai/*` imports are allowed but stripped)
-- No `require()` calls
-- `Image` `src` values must be `http://` or `https://` URLs
-
-**Minimal working example:**
-
-```tsx
-export default (
-  <Render width={1080} height={1920}>
-    <Clip duration={5}>
-      <Video prompt="a cat playing piano" model={varg.videoModel("kling-v3")} duration={5} />
-    </Clip>
-  </Render>
-);
-```
-
-**Full example with multiple clips:**
-
-```tsx
-const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
-  prompt: "cinematic portrait, golden hour lighting",
-  aspectRatio: "9:16"
-});
-
-const vid = Video({
-  model: varg.videoModel("kling-v3"),
-  prompt: { text: "person walks forward, camera follows", images: [img] },
-  duration: 5
-});
-
-const voice = Speech({
-  model: varg.speechModel("eleven_v3"),
-  voice: "rachel",
-  children: "Welcome to our show!"
-});
-
-export default (
-  <Render width={1080} height={1920} fps={30}>
-    <Music model={varg.musicModel("music_v1")} prompt="epic orchestral" duration={10} volume={0.3} />
-    <Clip duration={5}>
-      {vid}
-      <Title position="bottom">Welcome</Title>
-    </Clip>
-    <Captions src={voice} style="tiktok" withAudio />
-  </Render>
-);
-```
-
-### Render API Error Responses
-
-| Status | Meaning |
-|--------|---------|
-| 400 | Invalid TSX code, missing `export default`, or Zod validation failure |
-| 401 | Missing or invalid Bearer token |
-| 429 | Rate limit or concurrency limit exceeded (`Retry-After` header included) |
-| 503 | Queue unavailable (Redis/BullMQ down) |
+| v1 | v2 |
+|----|----|
+| `api.varg.ai/v1` | `api.varg.ai/v2` |
+| `job_id` field | `id` field |
+| `output.url` (single) | `output.outputs[]` (array, each with `file_id`) |
+| `GET /jobs/{id}/stream` (SSE) | Removed — poll or `options.webhook_url` |
+| `DELETE /jobs/{id}` | `POST /jobs/{id}/cancel` |
+| `GET /balance` | `GET /billing/balance` |
+| `GET /usage` | `GET /billing/usage` |
+| `POST /ffmpeg/trim` etc. | Single `POST /ffmpeg`, op selected by `model` |
+| `POST /ffmpeg/probe` | `POST /files/probe` |
+| `GET /voices` | Not ported — pass `voice` by name |
+| `render.varg.ai/api/render` | `POST api.varg.ai/v2/render` |
+| `X-Provider-Key-*` BYOK headers | Removed |
+| Files max 50MB | Max 200MB |
+| Flat error shape | `{"error": {"code", "message"}}` envelope |

--- a/varg-ai/references/local-render.md
+++ b/varg-ai/references/local-render.md
@@ -45,7 +45,7 @@ import { createVarg } from "vargai/ai"
 const varg = createVarg({ apiKey: process.env.VARG_API_KEY! })
 
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "a cozy cabin in mountains at sunset, warm golden light",
   aspectRatio: "16:9"
 })
@@ -67,13 +67,13 @@ import { createVarg } from "vargai/ai"
 const varg = createVarg({ apiKey: process.env.VARG_API_KEY! })
 
 const hero = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "cinematic portrait of a warrior princess, golden hour lighting",
   aspectRatio: "9:16"
 })
 
 const scene = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "warrior walks forward through misty forest, camera follows", images: [hero] },
   duration: 5
 })

--- a/varg-ai/references/models.md
+++ b/varg-ai/references/models.md
@@ -2,77 +2,73 @@
 
 1 credit = 1 cent. $1 = 100 credits.
 
+> Credits below are **estimates** from the live catalog. Always verify with `GET https://api.varg.ai/v2/pricing` (public, no auth) or price the exact request with `POST /v2/estimate` (same body as the generation call, no job created).
+
 ## Video Models
 
 Use with `varg.videoModel("id")`.
 
-| Model ID | Credits | Duration | Notes |
+| Model ID | Credits (~) | Duration | Notes |
 |----------|---------|----------|-------|
-| `kling-v3` | 150 | 3-15s (integer) | **Best quality (default)**. O3 Pro tier. |
-| `kling-v3-standard` | 100 | 3-15s (integer) | O3 Standard tier. Good quality, cheaper. |
-| `seedance-2-preview` | 250 | **5 or 10 ONLY** | ByteDance Seedance 2. Excellent quality. Auto watermark removal. |
-| `seedance-2-fast-preview` | 150 | **5 or 10 ONLY** | ByteDance Seedance 2 Fast. Faster generation, auto watermark removal. |
-| `kling-v2.6` | 150 | 3-15s (integer) | Native audio support: `providerOptions: { varg: { generate_audio: true } }` |
-| `kling-v2.5` | 100 | **5 or 10 ONLY** | Legacy. Any other duration causes 422 error. |
-| `kling-v2.1` | 100 | 5 or 10 | Legacy. |
-| `kling-v2` | 100 | 5 or 10 | Legacy. |
-| `wan-2.5` | 80 | varies | Fast and affordable. |
-| `wan-2.5-preview` | 60 | varies | Preview version. |
-| `minimax` | 80 | varies | Alternative provider. |
-| `ltx-2-19b-distilled` | 50 | varies | **Cheapest**. Uses `num_frames` not `duration`, `video_size` not `aspect_ratio`. Native audio support. |
-| `grok-imagine` | 100 | varies | xAI model. Native audio support. |
+| `kling_v3` | 221 | 3-15s (integer) | **Best quality (default)**. Pro tier. |
+| `kling_v3_standard` | 221 | 3-15s (integer) | Standard tier. |
+| `seedance_2_preview` | 394 | **5 or 10 ONLY** | ByteDance Seedance 2. Excellent quality. Auto watermark removal. |
+| `seedance_2_fast_preview` | 237 | **5 or 10 ONLY** | ByteDance Seedance 2 Fast. Faster generation, auto watermark removal. |
+| `sora_2` | 105 | varies | OpenAI video model. |
+| `sora_2_pro` | 315 | varies | OpenAI premium tier. |
+| `kling_v2.6` | varies | 3-15s (integer) | Native audio support: `providerOptions: { varg: { generate_audio: true } }` |
+| `kling_v2.5` | 147 | **5 or 10 ONLY** | Legacy. Any other duration causes 422 error. |
+| `kling_v2.1` | 147 | 5 or 10 | Legacy. |
+| `kling_v2` | 147 | 5 or 10 | Legacy. |
+| `wan_2.5` | 158 | varies | Fast and affordable. |
+| `wan_2.5_preview` | 158 | varies | Preview version. |
+| `minimax` | 84 | varies | Alternative provider. |
+| `ltx_2_19b_distilled` | 53 | varies | **Cheapest**. Uses `num_frames` not `duration`, `video_size` not `aspect_ratio`. Native audio support. |
+| `grok_imagine` | 105 | varies | xAI model. Native audio support. |
 
 ### Video Editing / Motion Control
 
-| Model ID | Credits | Notes |
+| Model ID | Credits (~) | Notes |
 |----------|---------|-------|
-| `grok-imagine-edit` | 100 | Video editing via xAI. |
-| `kling-v2.6-motion` | 150 | Motion control (camera trajectories). |
-| `kling-v2.6-motion-standard` | 100 | Motion control, standard tier. |
+| `grok_imagine_edit` | 105 | Video editing via xAI. |
+| `sora_2_remix` | 105 | Sora video remix. |
+| `kling_v2.6_motion` | 221 | Motion control (camera trajectories). |
 
 ### Lipsync Models
 
-| Model ID | Credits | Notes |
+| Model ID | Credits (~) | Notes |
 |----------|---------|-------|
-| `sync-v2` | 50 | Standard lipsync. |
-| `sync-v2-pro` | 80 | Higher quality lipsync. |
-| `lipsync` | 50 | Basic lipsync. |
-| `omnihuman-v1.5` | varies | Advanced human motion. |
-| `veed-fabric-1.0` | varies | VEED fabric lipsync. |
+| `sync_v2` | 53 | Standard lipsync. |
+| `sync_v2_pro` | 84 | Higher quality lipsync. |
+| `sync_v3` | 105 | Latest sync. |
+| `lipsync` | 53 | Basic lipsync. |
+| `omnihuman_v1.5` | ~1008 | Advanced human motion. Expensive. |
+| `veed_fabric_1.0` | ~473 | VEED fabric lipsync. |
 
 ### Lipsync Model Selection Guide
 
+**`veed_fabric_1.0` is the best and recommended model for talking heads.** It takes a still image + audio and produces a talking video directly — simplest pipeline, fastest results, best quality for speech-first workflows.
+
 | Model | Pipeline | Input | Speed | Quality | Best For |
 |-------|----------|-------|-------|---------|----------|
-| `veed-fabric-1.0` | Image + audio -> video | Still image + audio | Fast (~30-50s) | Good | Speech-first workflows, narrator clips |
-| `sync-v2-pro` | Video + audio -> video | Pre-animated video + audio | Medium (~60-90s) | Best | High-quality talking heads, facial detail |
-| `sync-v2` | Video + audio -> video | Pre-animated video + audio | Medium | Good | Budget alternative to sync-v2-pro |
-| `omnihuman-v1.5` | Image + audio -> video | Still image + audio | Slow | Variable | Full-body motion, experimental |
+| `veed_fabric_1.0` | Image + audio -> video | Still image + audio | Fast (~30-50s) | **Best** | **Talking heads, narrator clips (RECOMMENDED)** |
+| `sync_v2` | Video + audio -> video | Pre-animated video + audio | Medium | Good | Adding lip movement to existing video |
+| `omnihuman_v1.5` | Image + audio -> video | Still image + audio | Slow | Variable | Full-body motion, experimental |
 
 **Decision matrix:**
-- **"I have a speech audio and a character image"** -> `veed-fabric-1.0` (simplest, fastest)
-- **"I have an animated video and want to add lip movement"** -> `sync-v2-pro` (best quality)
-- **"I need full-body gestures matching speech"** -> `omnihuman-v1.5` (experimental)
+- **"I need a talking head"** -> `veed_fabric_1.0` (best, simplest, fastest)
+- **"I have a speech audio and a character image"** -> `veed_fabric_1.0`
+- **"I have an animated video and want to add lip movement"** -> `sync_v2`
+- **"I need full-body gestures matching speech"** -> `omnihuman_v1.5` (experimental)
 
-**VEED Fabric workflow** (speech-first):
+**VEED Fabric workflow** (recommended — speech-first):
 ```tsx
-const portrait = Image({ model: varg.imageModel("nano-banana-pro"), prompt: "..." });
+const portrait = Image({ model: varg.imageModel("nano_banana_pro"), prompt: "..." });
 const talking = Video({
-  model: varg.videoModel("veed-fabric-1.0"),
+  model: varg.videoModel("veed_fabric_1.0"),
   keepAudio: true,
   prompt: { images: [portrait], audio: speechSegment },
   providerOptions: { varg: { resolution: "720p" } },  // 480p or 720p only
-});
-```
-
-**sync-v2-pro workflow** (animate-then-lipsync):
-```tsx
-const portrait = Image({ ... });
-const animated = Video({ model: varg.videoModel("kling-v3"), prompt: { images: [portrait], text: "person talking" }, duration: 5 });
-const talking = Video({
-  model: varg.videoModel("sync-v2-pro"),
-  keepAudio: true,
-  prompt: { images: [animated], audio: speechSegment },
 });
 ```
 
@@ -80,22 +76,31 @@ const talking = Video({
 
 **Text-to-video** (string prompt):
 ```tsx
-Video({ model: varg.videoModel("kling-v3"), prompt: "a cat playing piano", duration: 5 })
+Video({ model: varg.videoModel("kling_v3"), prompt: "a cat playing piano", duration: 5 })
 ```
 
 **Image-to-video** (object prompt with ONE image):
 ```tsx
 Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "cat starts playing keys", images: [catImage] },
   duration: 5
 })
 ```
 
-**Lipsync** (video + audio):
+**Lipsync — image + audio** (recommended, VEED):
 ```tsx
 Video({
-  model: varg.videoModel("sync-v2-pro"),
+  model: varg.videoModel("veed_fabric_1.0"),
+  keepAudio: true,
+  prompt: { images: [portrait], audio: voiceover }
+})
+```
+
+**Lipsync — video + audio** (for pre-animated video):
+```tsx
+Video({
+  model: varg.videoModel("sync_v2"),
   prompt: { video: animatedCharacter, audio: voiceover }
 })
 ```
@@ -104,13 +109,13 @@ Video({
 
 ```tsx
 Video({
-  model: varg.videoModel("kling-v2.6"),
+  model: varg.videoModel("kling_v2.6"),
   prompt: "...",
   duration: 5,
   aspectRatio: "9:16",
   providerOptions: {
     varg: {
-      generate_audio: true,   // Native audio (kling-v2.6, ltx, grok)
+      generate_audio: true,   // Native audio (kling_v2.6, ltx, grok)
       resolution: "2K",       // Higher resolution
     }
   }
@@ -123,34 +128,33 @@ Video({
 
 Use with `varg.imageModel("id")`.
 
-| Model ID | Credits | Prompt Format | Notes |
+| Model ID | Credits (~) | Prompt Format | Notes |
 |----------|---------|---------------|-------|
-| `nano-banana-pro` | 5 | `string` | **Best default**. Text-to-image. |
-| `nano-banana-pro/edit` | 5 | `{ text, images }` | Reference-based editing. Always pass reference via `images: [ref]`. |
-| `nano-banana-2` | 5 | `{ text, images? }` | Newer model (slower). |
-| `nano-banana-2/edit` | 5 | `{ text, images }` | Explicit edit mode. |
-| `flux-schnell` | 5 | `string` | Fast text-to-image. |
-| `flux-dev` | 8 | `string` | Better quality Flux. |
-| `flux-pro` | 10 | `string` | Best Flux quality. |
-| `recraft-v3` | 10 | `string` | Stylized / design images. |
-| `recraft-v4-pro` | 10 | `string` | Latest Recraft. |
-| `seedream-v4.5/edit` | 5 | `{ text, images }` | ByteDance image editing. |
-| `qwen-angles` | 8 | `{ text, images }` | Multi-angle generation from reference. |
-| `qwen-image-2` | varies | `string` | Qwen image generation. |
-| `qwen-image-2-pro` | varies | `string` | Qwen pro tier. |
-| `soul` | 15 | `string` | Higgsfield character generation. 80+ style presets. |
+| `nano_banana_pro` | 126 | `string` | **Best quality**. Text-to-image. |
+| `nano_banana_pro/edit` | 126 | `{ text, images }` | Reference-based editing. Always pass reference via `images: [ref]`. |
+| `nano_banana_2` | 68 | `{ text, images? }` | Cheaper nano banana. |
+| `nano_banana_2/edit` | 68 | `{ text, images }` | Explicit edit mode. |
+| `grok_imagine_image` | 4 | `string` | **Cheapest**. xAI image generation. |
+| `flux_schnell` | ~5 | `string` | Fast text-to-image. |
+| `flux_dev` | 68 | `string` | Better quality Flux. |
+| `flux_pro` | 68 | `string` | Best Flux quality. |
+| `recraft_v3` | 11 | `string` | Stylized / design images. |
+| `seedream_v4.5/edit` | 53 | `{ text, images }` | ByteDance image editing. |
+| `qwen_angles` | 9 | `{ text, images }` | Multi-angle generation from reference. |
+| `phota` | 38 | `string` | Photorealistic generation. |
+| `soul` | 21 | `string` | Higgsfield character generation. 80+ style presets. |
 
 ### Image Prompt Examples
 
-**Text-to-image** (nano-banana-pro, flux):
+**Text-to-image** (nano_banana_pro, flux):
 ```tsx
-Image({ model: varg.imageModel("nano-banana-pro"), prompt: "a sunset over the ocean", aspectRatio: "16:9" })
+Image({ model: varg.imageModel("nano_banana_pro"), prompt: "a sunset over the ocean", aspectRatio: "16:9" })
 ```
 
-**Reference editing** (nano-banana-pro/edit):
+**Reference editing** (nano_banana_pro/edit):
 ```tsx
 Image({
-  model: varg.imageModel("nano-banana-pro/edit"),
+  model: varg.imageModel("nano_banana_pro/edit"),
   prompt: { text: "same person in a tropical beach setting", images: [referenceImage] },
   aspectRatio: "9:16"
 })
@@ -175,15 +179,17 @@ Most models support all standard ratios.
 
 Use with `varg.speechModel("id")`.
 
-| Model ID | Credits | Notes |
+| Model ID | Credits (~) | Notes |
 |----------|---------|-------|
-| `turbo` | 20 | Alias for `eleven_turbo_v2`. Fast, recommended. |
-| `eleven_turbo_v2` | 20 | Fast English TTS. |
-| `eleven_turbo_v2_5` | 20 | Updated turbo. |
-| `eleven_flash_v2` | 20 | Ultra-fast. |
-| `eleven_flash_v2_5` | 20 | Updated flash. |
-| `eleven_multilingual_v2` | 25 | Multi-language support. |
-| `eleven_v3` | 25 | Latest, highest quality. |
+| `turbo` | 105 | Alias for `eleven_turbo_v2`. Fast English only. |
+| `eleven_turbo_v2` | 105 | Fast English TTS. |
+| `eleven_turbo_v2_5` | 105 | Updated turbo. |
+| `eleven_flash_v2` | 105 | Ultra-fast. |
+| `eleven_flash_v2_5` | 105 | Updated flash. |
+| `eleven_multilingual_v2` | 210 | Multi-language support. |
+| `eleven_v3` | 210 | Latest, highest quality. |
+
+> Speech is billed per character — the credits above are catalog estimates for a typical utterance. Short lines cost less; use `POST /v2/estimate` with your actual `text` for the real price.
 
 ### Available Voices
 
@@ -233,9 +239,10 @@ const voice = Speech({
 
 Use with `varg.musicModel("music_v1")`.
 
-| Model ID | Credits | Notes |
+| Model ID | Credits (~) | Notes |
 |----------|---------|-------|
-| `music_v1` | 30 | AI music generation. Always set `duration`. |
+| `music_v1` | 79 | AI music generation. Always set `duration`. |
+| `eleven_music` | 79 | Alias. |
 
 ### Music Usage
 
@@ -255,25 +262,31 @@ Use with `varg.musicModel("music_v1")`.
 
 ## Transcription Models
 
-| Model ID | Credits | Notes |
+| Model ID | Credits (~) | Notes |
 |----------|---------|-------|
-| `whisper` | 10 | OpenAI Whisper via fal. |
-| `whisper-large-v3` | 10 | Whisper large model. |
+| `whisper` | 6 | OpenAI Whisper via fal. |
+| `whisper_large_v3` | 6 | Whisper large model. |
+| `groq_whisper_large_v3_turbo` | 4 | Fastest/cheapest via Groq. |
 
 ---
 
 ## Quick Reference: Recommended Defaults
 
-| Task | Model | Credits |
+| Task | Model | Credits (~) |
 |------|-------|---------|
-| Image (default) | `nano-banana-pro` | 5 |
-| Image editing | `nano-banana-pro/edit` | 5 |
-| Image (fast) | `flux-schnell` | 5 |
-| Video (default) | `kling-v3` | 150 |
-| Video (premium) | `seedance-2-preview` | 250 |
-| Video (budget) | `kling-v3-standard` | 100 |
-| Video (fast, ByteDance) | `seedance-2-fast-preview` | 150 |
-| Video (cheapest) | `ltx-2-19b-distilled` | 50 |
-| Speech | `eleven_v3` or `turbo` | 20-25 |
-| Music | `music_v1` | 30 |
-| Lipsync | `sync-v2-pro` | 80 |
+| Image (best quality) | `nano_banana_pro` | 126 |
+| Image editing | `nano_banana_pro/edit` | 126 |
+| Image (cheap) | `grok_imagine_image` | 4 |
+| Image (fast) | `flux_schnell` | ~5 |
+| Video (default) | `kling_v3` | 221 |
+| Video (premium) | `seedance_2_preview` | 394 |
+| Video (affordable) | `sora_2` | 105 |
+| Video (fast, ByteDance) | `seedance_2_fast_preview` | 237 |
+| Video (cheapest) | `ltx_2_19b_distilled` | 53 |
+| Speech (fast) | `eleven_turbo_v2_5` | ~105 |
+| Speech (best) | `eleven_v3` | ~210 |
+| Music | `music_v1` | 79 |
+| Lipsync (cheap, video+audio) | `sync_v2` | 53 |
+| Talking Head (image+audio) | `veed_fabric_1.0` | ~473 |
+
+Live catalog: `GET https://api.varg.ai/v2/pricing`.

--- a/varg-ai/references/prompting.md
+++ b/varg-ai/references/prompting.md
@@ -24,7 +24,7 @@ Be specific about appearance, clothing, expression:
 - "A golden retriever puppy with floppy ears"
 - "A weathered lighthouse on a rocky cliff"
 
-For characters appearing in multiple scenes, generate a reference image first and use `nano-banana-pro/edit` to maintain consistency (see SKILL.md character consistency section).
+For characters appearing in multiple scenes, generate a reference image first and use `nano_banana_pro/edit` to maintain consistency (see SKILL.md character consistency section).
 
 ---
 
@@ -114,7 +114,7 @@ Describe what happens in the scene. Be specific about movement direction and spe
 
 Some video models support native audio generation (speech, sound effects, ambient audio baked into the video). Enable with `providerOptions: { varg: { generate_audio: true } }`.
 
-**Supported models**: `kling-v2.6`, `ltx-2-19b-distilled`, `grok-imagine`
+**Supported models**: `kling_v2.6`, `ltx_2_19b_distilled`, `grok_imagine`
 
 ### Dialogue Formatting
 
@@ -136,7 +136,7 @@ Character says: "Your line here."
 ```tsx
 // Character with dialogue
 Video({
-  model: varg.videoModel("kling-v2.6"),
+  model: varg.videoModel("kling_v2.6"),
   prompt: "woman at a cafe table, she picks up her coffee and says: \"This is perfect.\" Warm smile, gentle ambient cafe sounds.",
   duration: 5,
   providerOptions: { varg: { generate_audio: true } }
@@ -144,7 +144,7 @@ Video({
 
 // Atmospheric scene (no dialogue)
 Video({
-  model: varg.videoModel("kling-v2.6"),
+  model: varg.videoModel("kling_v2.6"),
   prompt: "aerial shot of ocean waves crashing on rocky shore, no dialogue, ambient ocean sounds, wind, seagulls in distance",
   duration: 8,
   providerOptions: { varg: { generate_audio: true } }

--- a/varg-ai/references/recipes.md
+++ b/varg-ai/references/recipes.md
@@ -9,7 +9,7 @@ Common video workflows. All examples use `varg.*` syntax which works in both loc
 When a character or product appears across multiple clips, use this 3-step workflow to keep them looking the same:
 
 1. **Reference image** -- generate (or receive) a character hero shot
-2. **Scene images via /edit** -- use `nano-banana-pro/edit` to place the character into each scene, always passing the reference via `images: [ref]`
+2. **Scene images via /edit** -- use `nano_banana_pro/edit` to place the character into each scene, always passing the reference via `images: [ref]`
 3. **Animate via i2v** -- pass each scene image to `Video()` for image-to-video generation
 
 Never generate scene images from scratch -- they won't look like the same character.
@@ -18,31 +18,31 @@ Never generate scene images from scratch -- they won't look like the same charac
 // 1. Character reference
 const ref = Image({
   prompt: "a man in a dark suit, dramatic side lighting, neutral background",
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   aspectRatio: "9:16"
 })
 
 // 2. Scene images -- swap character into different environments
 const scene1 = Image({
   prompt: { text: "same man sitting at a wooden desk, warm lamp light", images: [ref] },
-  model: varg.imageModel("nano-banana-pro/edit"),
+  model: varg.imageModel("nano_banana_pro/edit"),
   aspectRatio: "9:16"
 })
 const scene2 = Image({
   prompt: { text: "same man standing by a tall window, cold grey daylight", images: [ref] },
-  model: varg.imageModel("nano-banana-pro/edit"),
+  model: varg.imageModel("nano_banana_pro/edit"),
   aspectRatio: "9:16"
 })
 
 // 3. Animate each scene
 const vid1 = Video({
   prompt: { text: "man looks up from desk, slight head turn", images: [scene1] },
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   duration: 5
 })
 const vid2 = Video({
   prompt: { text: "man turns from window, eyes cast down", images: [scene2] },
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   duration: 5
 })
 
@@ -72,7 +72,7 @@ Full audio placed at `<Render>` level for continuous playback. Lipsync clips use
 // 1. AUDIO FIRST -- one call produces segments with timing
 const { audio, segments } = await Speech({
   voice: "rachel",
-  model: varg.speechModel("turbo"),
+  model: varg.speechModel("eleven_v3"),
   children: [
     "Welcome to the future of content creation.",
     "Our AI generates stunning visuals in seconds.",
@@ -82,24 +82,24 @@ const { audio, segments } = await Speech({
 
 // 2. Generate a portrait for lipsync
 const portrait = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "friendly female host, studio background, looking at camera",
   aspectRatio: "9:16"
 })
 
 // 3. VISUALS -- durations come from segment timing
 const talking1 = Video({
-  model: varg.videoModel("veed-fabric-1.0"),
+  model: varg.videoModel("veed_fabric_1.0"),
   keepAudio: false,  // audio comes from the voiceover track
   prompt: { images: [portrait], audio: segments[0] },
 })
 const brollImg = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "sleek product dashboard, glowing UI",
   aspectRatio: "9:16"
 })
 const talking2 = Video({
-  model: varg.videoModel("veed-fabric-1.0"),
+  model: varg.videoModel("veed_fabric_1.0"),
   keepAudio: false,
   prompt: { images: [portrait], audio: segments[2] },
 })
@@ -124,7 +124,7 @@ Each segment placed as a clip child. Lipsync clips use `keepAudio: true` so the 
 ```tsx
 const { segments } = await Speech({
   voice: "adam",
-  model: varg.speechModel("turbo"),
+  model: varg.speechModel("eleven_v3"),
   children: [
     "Scene one narration goes here.",
     "Scene two is a b-roll with voiceover.",
@@ -132,11 +132,11 @@ const { segments } = await Speech({
   ]
 })
 
-const portrait = Image({ model: varg.imageModel("nano-banana-pro"), prompt: "male host, studio, looking at camera", aspectRatio: "9:16" })
+const portrait = Image({ model: varg.imageModel("nano_banana_pro"), prompt: "male host, studio, looking at camera", aspectRatio: "9:16" })
 
-const talking1 = Video({ model: varg.videoModel("veed-fabric-1.0"), keepAudio: true, prompt: { images: [portrait], audio: segments[0] } })
-const brollImg = Image({ model: varg.imageModel("nano-banana-pro"), prompt: "city skyline timelapse", aspectRatio: "9:16" })
-const talking2 = Video({ model: varg.videoModel("veed-fabric-1.0"), keepAudio: true, prompt: { images: [portrait], audio: segments[2] } })
+const talking1 = Video({ model: varg.videoModel("veed_fabric_1.0"), keepAudio: true, prompt: { images: [portrait], audio: segments[0] } })
+const brollImg = Image({ model: varg.imageModel("nano_banana_pro"), prompt: "city skyline timelapse", aspectRatio: "9:16" })
+const talking2 = Video({ model: varg.videoModel("veed_fabric_1.0"), keepAudio: true, prompt: { images: [portrait], audio: segments[2] } })
 
 export default (
   <Render width={1080} height={1920}>
@@ -158,52 +158,46 @@ export default (
 
 ## Talking Head (character + speech + lipsync + captions)
 
-Full pipeline: generate a character, animate them, create voiceover, lipsync the audio to the video, add captions.
+**Best model for talking heads: `veed_fabric_1.0`** — takes a still image + audio and produces a talking video directly. No animation step needed. Simplest and fastest pipeline.
 
 ```tsx
-// 1. Generate character
+// 1. Generate character portrait
 const character = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "friendly female tech host, professional studio background, warm smile, looking at camera",
   aspectRatio: "9:16"
 })
 
-// 2. Animate character
-const animated = Video({
-  model: varg.videoModel("kling-v3"),
-  prompt: { text: "woman talks naturally to camera, subtle hand gestures, professional demeanor", images: [character] },
-  duration: 10
-})
-
-// 3. Generate voiceover
-const voice = Speech({
+// 2. Generate voiceover
+const voice = await Speech({
   model: varg.speechModel("eleven_v3"),
   voice: "rachel",
   children: "Hey everyone! Welcome back to the channel. Today we're going to talk about something really exciting."
 })
 
-// 4. Lipsync video to speech
-const synced = Video({
-  model: varg.videoModel("sync-v2-pro"),
-  prompt: { video: animated, audio: voice }
+// 3. Lipsync image + audio directly (VEED — one step, no animation needed)
+const talking = Video({
+  model: varg.videoModel("veed_fabric_1.0"),
+  keepAudio: true,
+  prompt: { images: [character], audio: voice }
 })
 
-// 5. Compose
+// 4. Compose
 export default (
   <Render width={1080} height={1920}>
-    <Clip duration={10}>{synced}</Clip>
-    <Captions src={voice} style="tiktok" position="bottom" withAudio />
+    <Clip duration={voice.duration}>{talking}</Clip>
+    <Captions src={voice} style="tiktok" position="bottom" />
   </Render>
 )
 ```
 
-**Cost**: ~310 credits ($3.10) -- 5 (image) + 150 (video) + 25 (speech) + 80 (lipsync) + 50 (captions/transcription)
+**Cost**: ~180 credits ($1.80) -- 5 (image) + 25 (speech) + 100 (veed lipsync) + 50 (captions/transcription)
 
 ---
 
 ## Longer Videos (chained clips)
 
-Each video clip is 3-15 seconds (kling-v3). Chain multiple clips with transitions for longer videos:
+Each video clip is 3-15 seconds (kling_v3). Chain multiple clips with transitions for longer videos:
 
 ```tsx
 <Render width={1080} height={1920}>
@@ -224,7 +218,7 @@ Generate a slideshow from an array of prompts. Easy to customize for any topic.
 ```tsx
 const slides = ["sunset over ocean", "mountain peak at dawn", "forest path in autumn"]
 const images = slides.map(prompt =>
-  Image({ model: varg.imageModel("nano-banana-pro"), prompt, aspectRatio: "16:9" })
+  Image({ model: varg.imageModel("nano_banana_pro"), prompt, aspectRatio: "16:9" })
 )
 
 export default (
@@ -251,7 +245,7 @@ Full audio setup with background music that ducks under speech:
 
 ```tsx
 const speech = Speech({
-  model: varg.speechModel("turbo"),
+  model: varg.speechModel("eleven_v3"),
   voice: "adam",
   children: "Welcome to the showcase. Today we have something special for you."
 })
@@ -277,7 +271,7 @@ The `ducking` prop automatically lowers music volume when speech is playing.
 
 ### Pattern: AI Narrator + Subject Character Scenes
 
-Mix a consistent AI narrator character (VEED lipsync) with generated scenes featuring the recipient (nano-banana-pro/edit with reference photos).
+Mix a consistent AI narrator character (VEED lipsync) with generated scenes featuring the recipient (nano_banana_pro/edit with reference photos).
 
 **Ingredients:**
 - 1-3 reference photos of the recipient (portrait headshot = most important)
@@ -289,9 +283,9 @@ Mix a consistent AI narrator character (VEED lipsync) with generated scenes feat
 
 1. **Speech first**: Single `await Speech()` call with all narrator lines as array children. Returns `{ audio, segments }` -- each segment has `.duration` for clip timing.
 
-2. **Narrator character**: Generate a base image (`nano-banana-pro`), then 3-4 angle variants via `nano-banana-pro/edit` referencing the base. Use VEED lipsync for talking clips.
+2. **Narrator character**: Generate a base image (`nano_banana_pro`), then 3-4 angle variants via `nano_banana_pro/edit` referencing the base. Use VEED lipsync for talking clips.
 
-3. **Subject scenes**: Use `nano-banana-pro/edit` with the recipient's portrait headshot as reference image. Add style reference images for environment/aesthetic consistency.
+3. **Subject scenes**: Use `nano_banana_pro/edit` with the recipient's portrait headshot as reference image. Add style reference images for environment/aesthetic consistency.
 
 4. **Composition**: Alternate narrator clips and subject scene clips. Narrator clips use VEED `keepAudio: true`. Scene clips use the speech segment as clip child for voiceover.
 
@@ -310,19 +304,19 @@ const { audio, segments } = await Speech({
 })
 
 const narrator = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "friendly AI robot character, warm smile, studio background",
   aspectRatio: "9:16"
 })
 
 const talking = Video({
-  model: varg.videoModel("veed-fabric-1.0"),
+  model: varg.videoModel("veed_fabric_1.0"),
   keepAudio: true,
   prompt: { images: [narrator], audio: segments[0] },
 })
 
 const scene1 = Image({
-  model: varg.imageModel("nano-banana-pro/edit"),
+  model: varg.imageModel("nano_banana_pro/edit"),
   prompt: { text: "same person in a futuristic celebration scene", images: [recipientRef] },
   aspectRatio: "9:16"
 })
@@ -338,7 +332,7 @@ export default (
 
 **Key tips:**
 - Keep `Speech()` parameters IDENTICAL between renders (avoids cache invalidation cascade -- see [common-errors.md](common-errors.md))
-- Upload reference photos to S3 first (gateway `POST /v1/files`)
+- Upload reference photos first (`POST /v2/files`, raw binary body, max 200MB) and use the returned `url`
 - Use descriptive character consistency prompts: "Same man -- dark beard, warm smile, same face"
 - VEED Fabric 1.0 is fastest for narrator lipsync (image + audio -> talking video)
 

--- a/varg-ai/references/templates.md
+++ b/varg-ai/references/templates.md
@@ -18,13 +18,13 @@ These examples show the complete cloud render workflow using `curl`. No bun or f
 # Write TSX code to a file first (for reference/iteration)
 cat > video.tsx << 'TEMPLATE'
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "a cozy cabin in the mountains at sunset, warm golden light, snow on peaks",
   aspectRatio: "16:9"
 });
 
 const vid = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "gentle camera push-in, smoke rising from chimney, birds flying across sky", images: [img] },
   duration: 5
 });
@@ -37,11 +37,11 @@ export default (
 TEMPLATE
 
 # Submit to render service (requires jq)
-JOB_ID=$(curl -s -X POST https://render.varg.ai/api/render \
+JOB_ID=$(curl -s -X POST https://api.varg.ai/v2/render \
   -H "Authorization: Bearer $VARG_API_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"code\": $(cat video.tsx | jq -Rs .)}" \
-  | jq -r '.job_id')
+  | jq -r '.id')
 
 echo "Job submitted: $JOB_ID"
 ```
@@ -53,12 +53,12 @@ echo "Job submitted: $JOB_ID"
 # Read TSX and escape it for JSON (no jq needed)
 CODE=$(sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' video.tsx | tr -d '\n' | sed 's/\\n$//')
 
-RESPONSE=$(curl -s -X POST https://render.varg.ai/api/render \
+RESPONSE=$(curl -s -X POST https://api.varg.ai/v2/render \
   -H "Authorization: Bearer $VARG_API_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"code\": \"$CODE\"}")
 
-JOB_ID=$(echo "$RESPONSE" | grep -o '"job_id":"[^"]*"' | cut -d'"' -f4)
+JOB_ID=$(echo "$RESPONSE" | grep -o '"id":"job_[^"]*"' | cut -d'"' -f4)
 echo "Job submitted: $JOB_ID"
 ```
 
@@ -67,17 +67,17 @@ echo "Job submitted: $JOB_ID"
 ### Poll for result
 
 ```bash
-# Poll until status is "completed" or "failed"
+# Poll until status is "completed", "failed", or "cancelled"
 while true; do
-  RESULT=$(curl -s "https://render.varg.ai/api/render/jobs/$JOB_ID" \
+  RESULT=$(curl -s "https://api.varg.ai/v2/jobs/$JOB_ID" \
     -H "Authorization: Bearer $VARG_API_KEY")
   STATUS=$(echo "$RESULT" | jq -r '.status')
   echo "Status: $STATUS"
   if [ "$STATUS" = "completed" ]; then
-    echo "$RESULT" | jq -r '.output_url'
+    echo "$RESULT" | jq -r '.output.outputs[0].url'
     break
-  elif [ "$STATUS" = "failed" ]; then
-    echo "$RESULT" | jq -r '.error'
+  elif [ "$STATUS" = "failed" ] || [ "$STATUS" = "cancelled" ]; then
+    echo "$RESULT" | jq -r '.error.message // .error'
     break
   fi
   sleep 10
@@ -89,15 +89,15 @@ done
 
 ```bash
 while true; do
-  RESULT=$(curl -s "https://render.varg.ai/api/render/jobs/$JOB_ID" \
+  RESULT=$(curl -s "https://api.varg.ai/v2/jobs/$JOB_ID" \
     -H "Authorization: Bearer $VARG_API_KEY")
   STATUS=$(echo "$RESULT" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
   echo "Status: $STATUS"
   if [ "$STATUS" = "completed" ]; then
-    echo "$RESULT" | grep -o '"output_url":"[^"]*"' | cut -d'"' -f4
+    echo "$RESULT" | grep -o '"url":"[^"]*"' | head -1 | cut -d'"' -f4
     break
-  elif [ "$STATUS" = "failed" ]; then
-    echo "$RESULT" | grep -o '"error":"[^"]*"' | cut -d'"' -f4
+  elif [ "$STATUS" = "failed" ] || [ "$STATUS" = "cancelled" ]; then
+    echo "$RESULT" | grep -o '"message":"[^"]*"' | cut -d'"' -f4
     break
   fi
   sleep 10
@@ -108,40 +108,37 @@ done
 
 ### Cloud render: Talking Head
 
+Uses **veed_fabric_1.0** — the best and simplest model for talking heads. Takes a still image + audio and produces a talking video directly (no animation step needed).
+
 ```bash
 cat > talking-head.tsx << 'TEMPLATE'
 const character = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "friendly female tech host, professional studio background, warm smile, looking at camera",
   aspectRatio: "9:16"
 });
 
-const animated = Video({
-  model: varg.videoModel("kling-v3"),
-  prompt: { text: "woman talks naturally to camera, subtle hand gestures", images: [character] },
-  duration: 10
-});
-
-const voice = Speech({
+const voice = await Speech({
   model: varg.speechModel("eleven_v3"),
   voice: "rachel",
   children: "Hey everyone! Welcome back. Today we are going to talk about something really exciting."
 });
 
-const synced = Video({
-  model: varg.videoModel("sync-v2-pro"),
-  prompt: { video: animated, audio: voice }
+const talking = Video({
+  model: varg.videoModel("veed_fabric_1.0"),
+  keepAudio: true,
+  prompt: { images: [character], audio: voice }
 });
 
 export default (
   <Render width={1080} height={1920}>
-    <Clip duration={10}>{synced}</Clip>
-    <Captions src={voice} style="tiktok" position="bottom" withAudio />
+    <Clip duration={voice.duration}>{talking}</Clip>
+    <Captions src={voice} style="tiktok" position="bottom" />
   </Render>
 );
 TEMPLATE
 
-curl -s -X POST https://render.varg.ai/api/render \
+curl -s -X POST https://api.varg.ai/v2/render \
   -H "Authorization: Bearer $VARG_API_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"code\": $(cat talking-head.tsx | jq -Rs .)}"
@@ -167,13 +164,13 @@ import { createVarg } from "vargai/ai"
 const varg = createVarg({ apiKey: process.env.VARG_API_KEY! })
 
 const img = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "a cozy cabin in the mountains at sunset, warm golden light, snow on peaks",
   aspectRatio: "16:9"
 })
 
 const vid = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "gentle camera push-in, smoke rising from chimney, birds flying across sky", images: [img] },
   duration: 5
 })
@@ -191,7 +188,7 @@ export default (
 
 ## 2. Talking Head -- Character + Speech + Lipsync + Captions
 
-Full talking-head pipeline with AI-generated character.
+Full talking-head pipeline using **veed_fabric_1.0** — the best and simplest model for talking heads. Takes a still image + audio directly (no animation step needed).
 
 ```tsx
 /** @jsxImportSource vargai */
@@ -200,42 +197,36 @@ import { createVarg } from "vargai/ai"
 
 const varg = createVarg({ apiKey: process.env.VARG_API_KEY! })
 
-// 1. Generate character
+// 1. Generate character portrait
 const character = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "friendly female tech host, professional studio background, warm smile, looking at camera",
   aspectRatio: "9:16"
 })
 
-// 2. Animate character
-const animated = Video({
-  model: varg.videoModel("kling-v3"),
-  prompt: { text: "woman talks naturally to camera, subtle hand gestures, professional demeanor", images: [character] },
-  duration: 10
-})
-
-// 3. Generate voiceover
-const voice = Speech({
+// 2. Generate voiceover
+const voice = await Speech({
   model: varg.speechModel("eleven_v3"),
   voice: "rachel",
   children: "Hey everyone! Welcome back to the channel. Today we're going to talk about something really exciting."
 })
 
-// 4. Lipsync video to speech
-const synced = Video({
-  model: varg.videoModel("sync-v2-pro"),
-  prompt: { video: animated, audio: voice }
+// 3. Lipsync image + audio directly (VEED — one step)
+const talking = Video({
+  model: varg.videoModel("veed_fabric_1.0"),
+  keepAudio: true,
+  prompt: { images: [character], audio: voice }
 })
 
 export default (
   <Render width={1080} height={1920}>
-    <Clip duration={10}>{synced}</Clip>
-    <Captions src={voice} style="tiktok" position="bottom" withAudio />
+    <Clip duration={voice.duration}>{talking}</Clip>
+    <Captions src={voice} style="tiktok" position="bottom" />
   </Render>
 )
 ```
 
-**Cost**: ~310 credits ($3.10) -- 5 (image) + 150 (video) + 25 (speech) + 80 (lipsync) + 50 (captions/transcription)
+**Cost**: ~180 credits ($1.80) -- 5 (image) + 25 (speech) + 100 (veed lipsync) + 50 (captions/transcription)
 
 ---
 
@@ -256,43 +247,43 @@ const BRAND = "AuraSound"
 
 // -- Character reference (for consistency) --
 const model_ref = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "young woman, casual streetwear, confident expression, neutral background",
   aspectRatio: "9:16"
 })
 
 // -- Scene 1: Hero product shot --
 const heroImg = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: `${PRODUCT}, floating against dark gradient, dramatic studio lighting`,
   aspectRatio: "9:16"
 })
 const heroVid = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "slow 360 rotation, light rays catching surface, camera orbits", images: [heroImg] },
   duration: 5
 })
 
 // -- Scene 2: Lifestyle (character using product) --
 const lifestyleImg = Image({
-  model: varg.imageModel("nano-banana-pro/edit"),
+  model: varg.imageModel("nano_banana_pro/edit"),
   prompt: { text: "same woman wearing wireless earbuds, walking through city street, golden hour", images: [model_ref] },
   aspectRatio: "9:16"
 })
 const lifestyleVid = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "woman walks confidently, bobbing head to music, city blurs behind", images: [lifestyleImg] },
   duration: 5
 })
 
 // -- Scene 3: Close-up detail --
 const detailImg = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: `extreme close-up of ${PRODUCT}, touch controls glowing blue, soft bokeh`,
   aspectRatio: "9:16"
 })
 const detailVid = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "finger taps earbud, blue pulse radiates outward, satisfying click", images: [detailImg] },
   duration: 5
 })
@@ -347,7 +338,7 @@ const slides = [
 ]
 
 const images = slides.map(prompt =>
-  Image({ model: varg.imageModel("nano-banana-pro"), prompt, aspectRatio: "16:9" })
+  Image({ model: varg.imageModel("nano_banana_pro"), prompt, aspectRatio: "16:9" })
 )
 
 const totalDuration = slides.length * 3
@@ -380,23 +371,23 @@ import { createVarg } from "vargai/ai"
 const varg = createVarg({ apiKey: process.env.VARG_API_KEY! })
 
 const beforeImg = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "messy cluttered desk, papers everywhere, dim lighting",
   aspectRatio: "9:16"
 })
 const beforeVid = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "camera slowly reveals the chaos, papers flutter", images: [beforeImg] },
   duration: 5
 })
 
 const afterImg = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "perfectly organized minimalist desk, clean lines, bright natural light",
   aspectRatio: "9:16"
 })
 const afterVid = Video({
-  model: varg.videoModel("kling-v3"),
+  model: varg.videoModel("kling_v3"),
   prompt: { text: "camera glides across clean surface, light catches polished wood", images: [afterImg] },
   duration: 5
 })
@@ -431,7 +422,7 @@ const varg = createVarg({ apiKey: process.env.VARG_API_KEY! })
 
 // 1. Character reference
 const ref = Image({
-  model: varg.imageModel("nano-banana-pro"),
+  model: varg.imageModel("nano_banana_pro"),
   prompt: "a woman in her 30s, dark hair in a ponytail, wearing a leather jacket, determined expression",
   aspectRatio: "9:16"
 })
@@ -445,7 +436,7 @@ const scenes = [
 
 const sceneImages = scenes.map(s =>
   Image({
-    model: varg.imageModel("nano-banana-pro/edit"),
+    model: varg.imageModel("nano_banana_pro/edit"),
     prompt: { text: `same woman ${s.env}`, images: [ref] },
     aspectRatio: "9:16"
   })
@@ -453,7 +444,7 @@ const sceneImages = scenes.map(s =>
 
 const sceneVideos = scenes.map((s, i) =>
   Video({
-    model: varg.videoModel("kling-v3"),
+    model: varg.videoModel("kling_v3"),
     prompt: { text: s.motion, images: [sceneImages[i]] },
     duration: 5
   })

--- a/varg-ai/scripts/setup.sh
+++ b/varg-ai/scripts/setup.sh
@@ -59,13 +59,13 @@ if [ -n "${VARG_API_KEY:-}" ]; then
   if command -v curl &>/dev/null; then
     RESPONSE=$(curl -s -w "\n%{http_code}" \
       -H "Authorization: Bearer $VARG_API_KEY" \
-      "https://api.varg.ai/v1/balance" 2>/dev/null || echo "error")
+      "https://api.varg.ai/v2/billing/balance" 2>/dev/null || echo "error")
 
     HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
     BODY=$(echo "$RESPONSE" | sed '$d')
 
     if [ "$HTTP_CODE" = "200" ]; then
-      BALANCE=$(echo "$BODY" | grep -o '"balance_cents":[0-9]*' | grep -o '[0-9]*' || echo "")
+      BALANCE=$(echo "$BODY" | grep -o '"available":[0-9]*' | grep -o '[0-9]*' || echo "")
       if [ -n "$BALANCE" ]; then
         DOLLARS=$(echo "scale=2; $BALANCE / 100" | bc 2>/dev/null || echo "?")
         echo "  $(green '[OK]') Gateway connected. Balance: $BALANCE credits (\$$DOLLARS)"
@@ -90,13 +90,13 @@ elif check_saved_credentials; then
   if command -v curl &>/dev/null; then
     RESPONSE=$(curl -s -w "\n%{http_code}" \
       -H "Authorization: Bearer $VARG_API_KEY" \
-      "https://api.varg.ai/v1/balance" 2>/dev/null || echo "error")
+      "https://api.varg.ai/v2/billing/balance" 2>/dev/null || echo "error")
 
     HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
     BODY=$(echo "$RESPONSE" | sed '$d')
 
     if [ "$HTTP_CODE" = "200" ]; then
-      BALANCE=$(echo "$BODY" | grep -o '"balance_cents":[0-9]*' | grep -o '[0-9]*' || echo "")
+      BALANCE=$(echo "$BODY" | grep -o '"available":[0-9]*' | grep -o '[0-9]*' || echo "")
       if [ -n "$BALANCE" ]; then
         DOLLARS=$(echo "scale=2; $BALANCE / 100" | bc 2>/dev/null || echo "?")
         echo "  $(green '[OK]') Gateway connected. Balance: $BALANCE credits (\$$DOLLARS)"
@@ -166,7 +166,7 @@ if [ "$HAS_BUN" -eq 1 ] && [ "$HAS_FFMPEG" -eq 1 ] && [ "$HAS_FFPROBE" -eq 1 ]; 
   dim "    bunx vargai render video.tsx --verbose   (full render)"
   echo ""
   echo "  Cloud render (via API):"
-  echo "  $(dim '  curl -X POST https://render.varg.ai/api/render \')"
+  echo "  $(dim '  curl -X POST https://api.varg.ai/v2/render \')"
   echo "  $(dim '    -H "Authorization: Bearer $VARG_API_KEY" \')"
   echo "  $(dim '    -H "Content-Type: application/json" \')"
   echo "  $(dim '    -d '\''{"code": "..."}'\''')"
@@ -176,7 +176,7 @@ else
   echo ""
   echo "  Send TSX code to the render service via curl:"
   echo ""
-  echo "  $(dim 'curl -X POST https://render.varg.ai/api/render \')"
+  echo "  $(dim 'curl -X POST https://api.varg.ai/v2/render \')"
   echo "  $(dim '  -H "Authorization: Bearer $VARG_API_KEY" \')"
   echo "  $(dim '  -H "Content-Type: application/json" \')"
   echo "  $(dim '  -d '\''{"code": "export default (<Render>...</Render>)"}'\''')"

--- a/varg-ai/scripts/setup.ts
+++ b/varg-ai/scripts/setup.ts
@@ -51,14 +51,14 @@ function checkSavedCredentials(): { apiKey: string; email: string } | undefined 
 
 async function checkGateway(apiKey: string): Promise<boolean> {
   try {
-    const res = await fetch(`${GATEWAY_URL}/v1/balance`, {
+    const res = await fetch(`${GATEWAY_URL}/v2/billing/balance`, {
       headers: { Authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(5000),
     })
     if (res.ok) {
-      const data = await res.json() as { balance_cents?: number }
-      const credits = data.balance_cents ?? 0
-      console.log(green(`  ✓ Gateway connected. Balance: ${credits} credits ($${(credits / 100).toFixed(2)})`))
+      const data = await res.json() as { available?: number; total_balance?: number }
+      const credits = data.available ?? data.total_balance ?? 0
+      console.log(green(`  ✓ API connected. Balance: ${credits} credits ($${(credits / 100).toFixed(2)})`))
       return true
     }
     if (res.status === 401) {
@@ -187,13 +187,13 @@ import { Render, Clip, Image, Video } from "vargai/react"
 ${importLine}
 
 const img = Image({
-  model: ${modelPrefix}.imageModel("nano-banana-pro"),
+  model: ${modelPrefix}.imageModel("nano_banana_pro"),
   prompt: "a cozy cabin in the mountains at sunset, warm golden light",
   aspectRatio: "16:9"
 })
 
 const vid = Video({
-  model: ${modelPrefix}.videoModel("kling-v3"),
+  model: ${modelPrefix}.videoModel("kling_v3"),
   prompt: { text: "gentle push-in, smoke rising from chimney", images: [img] },
   duration: 5
 })


### PR DESCRIPTION
## Summary

Production `api.varg.ai` now serves the v2 API — this PR updates every stale v1 reference across the varg-ai skill (13 files, verified against the live API and the `varg-api-proto` implementation).

- **gateway-api.md**: full rewrite for `/v2` — generation endpoints (incl. new unified `POST /v2/ffmpeg` with `rendi_ffmpeg*` models, `POST /v2/render`, `POST /v2/pipeline`), job lifecycle (`id`, `output.outputs[]`, cancel/retry/refresh), tools discovery (`GET /tools`, `?model=`, `/call`), files (200MB, import/probe/check), `POST /estimate` + public `GET /pricing`, billing, `Idempotency-Key`, webhooks via `options.webhook_url`, error envelope, and a v1→v2 migration table
- **byok.md**: rewrite — **BYOK via the API is NOT available in v2** (no `X-Provider-Key-*` headers; external providers always run on pooled keys). Only local-SDK direct provider modules with env keys work. The old doc promised "$0 varg billing" through the API, which would silently bill credits
- **cloud-render.md / templates.md / SKILL.md**: `render.varg.ai/api/render` → `POST api.varg.ai/v2/render`; `job_id` → `id`; `output_url` → `output.outputs[0].url`; SSE dropped in favor of polling + webhooks
- **scripts/setup.sh + setup.ts**: balance check moved to `GET /v2/billing/balance` parsing the `available` field
- **models.md**: credit estimates refreshed from the live `/v2/pricing` catalog (old figures significantly understated — kling_v3 is ~221 credits, not 150); added sora_2, phota, grok_imagine_image; note pointing agents at `GET /v2/pricing` / `POST /v2/estimate` for real prices
- **all files**: canonical underscore model ids (`kling_v3`, `nano_banana_pro`); dashes still accepted by the API

Also includes the pending local lipsync guidance updates (veed_fabric_1.0 as the recommended talking-head model) that were uncommitted on main.

## Verification

- `bash scripts/setup.sh` run end-to-end against prod: balance check works (`✓ Gateway connected. Balance: 12157 credits`)
- `GET https://api.varg.ai/v2/billing/balance` response shape confirmed live
- `bash -n setup.sh` — syntax OK
- Grep sweep: no remaining `api.varg.ai/v1`, `render.varg.ai`, `X-Provider-Key`, SSE, or `output_url` references (except intentional ones in the migration table)